### PR TITLE
feat(bc-02): implement video ingestion function

### DIFF
--- a/.github/docs/mimesis-architecture.md
+++ b/.github/docs/mimesis-architecture.md
@@ -18,7 +18,7 @@ YouTube (search & download) → Transcription → Style Learning → Story Gener
 | # | Bounded Context | Responsibility | Status |
 |---|---|---|---|
 | 1 | **Video Discovery** | Search YouTube by keyword, deduplicate, emit `VideoDiscovered` events | Designed |
-| 2 | **Video Ingestion** | Download video from YouTube URL, extract audio, store in Blob Storage | Prototype (notebook) |
+| 2 | **Video Ingestion** | Consume discovered video events, persist video/audio/metadata artifacts, emit `VideoIngested` events | Designed |
 | 3 | **Transcription** | Transcribe audio to text using Whisper, store transcription | Prototype (notebook) |
 | 4 | **Style Learning** | Analyse transcriptions, learn narrator's writing style, store style profile | Not started |
 | 5 | **Story Generation** | Generate new stories from news using learned style | Not started |
@@ -67,19 +67,45 @@ YouTube (search & download) → Transcription → Style Learning → Story Gener
 
 ---
 
-### BC-02 · Video Ingestion *(Prototype — not yet formally designed)*
+### BC-02 · Video Ingestion
 
-**Status**: Exists as notebook code (`main_notebook.ipynb`). Needs a formal Solution Design before promotion to production component.
+**Solution Design**: Created April 2026
 
-**Known capabilities** (from prototype):
-- Download YouTube video by URL using `pytubefix`
-- Extract audio to MP3 using `ffmpeg`
-- Store audio in local folder (to be migrated to Azure Blob Storage)
+**Aggregate Root**: `VideoIngestionAggregate`
 
-**Pending Design Decisions**:
-- Trigger mechanism (consuming `VideoDiscovered` from Service Bus vs direct URL input)
-- Azure Blob Storage path convention for audio files
-- Error handling and retry strategy
+**Key Domain Objects**:
+
+| Object | Type | Description |
+|---|---|---|
+| `VideoIngestionAggregate` | Aggregate Root | Coordinates ingestion lifecycle for one `videoId` |
+| `IngestionRecord` | Entity | Tracks status, retries, and completion timestamps |
+| `IngestionArtifactSet` | Entity | Blob artifact references for source video, audio, and metadata |
+| `BlobArtifactPath` | Value Object | Canonical artifact storage path |
+| `IngestionStatus` | Value Object | `PENDING`, `PROCESSING`, `COMPLETED`, `FAILED` |
+| `VideoIngested` | Domain Event | Emitted after all required artifacts are durably persisted |
+
+**Domain Events**:
+
+| Event | Producer | Consumer | Queue |
+|---|---|---|---|
+| `VideoDiscovered` | Video Discovery | Video Ingestion | `sb-queue-video-discovered` |
+| `VideoIngested` | Video Ingestion | Transcription | `sb-queue-video-ingested` |
+
+**Key Decisions**:
+- Trigger model: consume `VideoDiscovered` from Service Bus (`sb-queue-video-discovered`)
+- Download source media with `pytubefix` (complements BC-01 `google-api-python-client` usage)
+- Extract audio to MP3 via `ffmpeg`/`pydub`
+- Persist artifacts in Blob Storage (`raw-videos`, `extracted-audio`, `video-metadata`)
+- Metadata blob stores ingestion-owned metadata only (no full event envelope)
+- Deduplication/idempotency via Azure Table Storage ingestion ledger (`PartitionKey='video'`, `RowKey=videoId`)
+- Emit `VideoIngested` only after artifact completeness (video, audio, metadata)
+- Apply raw-video retention of 30 days via Blob lifecycle rules
+
+**Terraform Resources**:
+- `azurerm_servicebus_queue` (name: `sb-queue-video-ingested`)
+- `azurerm_storage_management_policy` (30-day retention for raw video blobs)
+- `azurerm_storage_table` (Ingestion Ledger)
+- `azurerm_role_assignment` (Service Bus Data Receiver/Sender, Blob Data Contributor, Table Data Contributor)
 
 ---
 
@@ -123,6 +149,7 @@ These ADRs apply to **all** bounded contexts and must not be re-litigated per co
 | Event | Producer BC | Consumer BC | Service Bus Queue | Schema Version |
 |---|---|---|---|---|
 | `VideoDiscovered` | Video Discovery | Video Ingestion | `sb-queue-video-discovered` | v1 |
+| `VideoIngested` | Video Ingestion | Transcription | `sb-queue-video-ingested` | v1 |
 
 ---
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -64,6 +64,49 @@ resource "azurerm_storage_table" "discovery_ledger" {
   storage_account_name = azurerm_storage_account.main.name
 }
 
+resource "azurerm_storage_table" "ingestion_ledger" {
+  name                 = "ingestionLedger"
+  storage_account_name = azurerm_storage_account.main.name
+}
+
+resource "azurerm_storage_container" "raw_videos" {
+  name                  = "raw-videos"
+  storage_account_name  = azurerm_storage_account.main.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "extracted_audio" {
+  name                  = "extracted-audio"
+  storage_account_name  = azurerm_storage_account.main.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_container" "video_metadata" {
+  name                  = "video-metadata"
+  storage_account_name  = azurerm_storage_account.main.name
+  container_access_type = "private"
+}
+
+resource "azurerm_storage_management_policy" "main" {
+  storage_account_id = azurerm_storage_account.main.id
+
+  rule {
+    name    = "delete-raw-videos-after-30-days"
+    enabled = true
+
+    filters {
+      blob_types   = ["blockBlob"]
+      prefix_match = ["raw-videos/"]
+    }
+
+    actions {
+      base_blob {
+        delete_after_days_since_modification_greater_than = 30
+      }
+    }
+  }
+}
+
 # ── Service Bus ───────────────────────────────────────────────────────────────
 # Standard SKU: supports AMQP, duplicate detection, and at-least-once delivery
 # (ADR-02).
@@ -86,6 +129,15 @@ resource "azurerm_servicebus_queue" "video_discovered" {
   duplicate_detection_history_time_window = "PT10M"
 
   max_delivery_count = 10
+}
+
+resource "azurerm_servicebus_queue" "video_ingested" {
+  name         = "sb-queue-video-ingested"
+  namespace_id = azurerm_servicebus_namespace.main.id
+
+  requires_duplicate_detection            = true
+  duplicate_detection_history_time_window = "PT10M"
+  max_delivery_count                      = 10
 }
 
 # ── Log Analytics Workspace (required by workspace-based App Insights) ────────

--- a/infrastructure/terraform/outputs.tf
+++ b/infrastructure/terraform/outputs.tf
@@ -33,6 +33,31 @@ output "service_bus_queue" {
   value       = azurerm_servicebus_queue.video_discovered.name
 }
 
+output "service_bus_ingested_queue" {
+  description = "Service Bus queue name for VideoIngested events — set as MIMESIS_SERVICE_BUS_INGESTED_QUEUE."
+  value       = azurerm_servicebus_queue.video_ingested.name
+}
+
+output "ingestion_ledger_table" {
+  description = "Azure Table name for BC-02 idempotency ledger — set as MIMESIS_INGESTION_LEDGER_TABLE."
+  value       = azurerm_storage_table.ingestion_ledger.name
+}
+
+output "raw_videos_container" {
+  description = "Blob container for source video retention."
+  value       = azurerm_storage_container.raw_videos.name
+}
+
+output "extracted_audio_container" {
+  description = "Blob container for extracted MP3 artifacts."
+  value       = azurerm_storage_container.extracted_audio.name
+}
+
+output "video_metadata_container" {
+  description = "Blob container for ingestion metadata JSON artifacts."
+  value       = azurerm_storage_container.video_metadata.name
+}
+
 output "app_insights_connection_string" {
   description = "Application Insights connection string — set as MIMESIS_APP_INSIGHTS_CONNECTION_STRING."
   value       = azurerm_application_insights.main.connection_string

--- a/infrastructure/terraform/rbac.tf
+++ b/infrastructure/terraform/rbac.tf
@@ -22,6 +22,12 @@ resource "azurerm_role_assignment" "mi_table_contributor" {
   principal_id         = azurerm_user_assigned_identity.main.principal_id
 }
 
+resource "azurerm_role_assignment" "mi_blob_contributor" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.main.principal_id
+}
+
 # ── Managed Identity: Service Bus Data Sender (Video Discovery producer) ──────
 
 resource "azurerm_role_assignment" "mi_sb_sender" {

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -34,6 +34,6 @@ variable "youtube_api_key" {
       az keyvault secret set --vault-name <name> --name youtube-api-key --value <key>
     then remove the azurerm_key_vault_secret resource from the state.
   EOT
-  type      = string
-  sensitive = true
+  type        = string
+  sensitive   = true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,15 @@ description = "AI pipeline: learn storyteller voice from YouTube, generate new s
 requires-python = ">=3.12"
 dependencies = [
     "google-api-python-client>=2.100.0",
+    "azure-functions>=1.21.0",
     "azure-identity>=1.15.0",
     "azure-keyvault-secrets>=4.7.0",
     "azure-data-tables>=12.4.0",
+    "azure-storage-blob>=12.22.0",
     "azure-servicebus>=7.11.0",
     "azure-monitor-opentelemetry>=1.0.0",
+    "pytubefix>=8.0.0",
+    "pydub>=0.25.1",
 ]
 
 [project.optional-dependencies]

--- a/src/mimesis/shared/observability.py
+++ b/src/mimesis/shared/observability.py
@@ -32,6 +32,4 @@ def configure_observability(
     """
     os.environ.setdefault("OTEL_SERVICE_NAME", service_name)
     configure_azure_monitor(connection_string=connection_string)
-    logger.info(
-        "Application Insights telemetry configured | service_name=%s", service_name
-    )
+    logger.info("Application Insights telemetry configured | service_name=%s", service_name)

--- a/src/mimesis/video_discovery/application/video_discovery_service.py
+++ b/src/mimesis/video_discovery/application/video_discovery_service.py
@@ -74,9 +74,7 @@ class VideoDiscoveryService:
             job.mark_failed()
             return job
         except Exception:
-            logger.exception(
-                "Unexpected error in run_search | job_id=%s", job.search_job_id
-            )
+            logger.exception("Unexpected error in run_search | job_id=%s", job.search_job_id)
             job.mark_failed()
             raise
 

--- a/src/mimesis/video_discovery/config.py
+++ b/src/mimesis/video_discovery/config.py
@@ -42,16 +42,10 @@ class VideoDiscoveryConfig:
         return cls(
             key_vault_url=_require("MIMESIS_KEY_VAULT_URL"),
             storage_account_url=_require("MIMESIS_STORAGE_ACCOUNT_URL"),
-            discovery_ledger_table=os.getenv(
-                "MIMESIS_DISCOVERY_LEDGER_TABLE", "discoveryLedger"
-            ),
+            discovery_ledger_table=os.getenv("MIMESIS_DISCOVERY_LEDGER_TABLE", "discoveryLedger"),
             service_bus_namespace=_require("MIMESIS_SERVICE_BUS_NAMESPACE"),
-            service_bus_queue=os.getenv(
-                "MIMESIS_SERVICE_BUS_QUEUE", "sb-queue-video-discovered"
-            ),
-            app_insights_connection_string=_require(
-                "MIMESIS_APP_INSIGHTS_CONNECTION_STRING"
-            ),
+            service_bus_queue=os.getenv("MIMESIS_SERVICE_BUS_QUEUE", "sb-queue-video-discovered"),
+            app_insights_connection_string=_require("MIMESIS_APP_INSIGHTS_CONNECTION_STRING"),
             default_max_results=int(os.getenv("MIMESIS_DEFAULT_MAX_RESULTS", "500")),
         )
 

--- a/src/mimesis/video_discovery/domain/models.py
+++ b/src/mimesis/video_discovery/domain/models.py
@@ -6,14 +6,14 @@ Value Objects  : SearchQuery, SearchFilters, VideoMetadata
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from enum import Enum
-from typing import ClassVar, Optional
+from enum import StrEnum
+from typing import ClassVar
 from uuid import UUID, uuid4
 
 
-class SearchJobStatus(str, Enum):
+class SearchJobStatus(StrEnum):
     PENDING = "PENDING"
     RUNNING = "RUNNING"
     COMPLETED = "COMPLETED"
@@ -24,16 +24,16 @@ class SearchJobStatus(str, Enum):
 class SearchFilters:
     """Optional YouTube search filter parameters."""
 
-    language: Optional[str] = None
+    language: str | None = None
     """Instructs the API to prefer results in this language (relevanceLanguage)."""
 
-    published_after: Optional[datetime] = None
+    published_after: datetime | None = None
     """Return only videos published after this UTC timestamp (RFC 3339)."""
 
-    video_duration: Optional[str] = None
+    video_duration: str | None = None
     """Filter by duration category: 'short' (<4 min), 'medium' (4-20 min), 'long' (>20 min)."""
 
-    region_code: Optional[str] = None
+    region_code: str | None = None
     """ISO 3166-1 alpha-2 region code (e.g. 'GB', 'BR')."""
 
     _VALID_DURATIONS: ClassVar[frozenset[str]] = frozenset({"short", "medium", "long"})
@@ -54,7 +54,7 @@ class SearchQuery:
     """A keyword plus optional filter parameters submitted to YouTube."""
 
     keyword: str
-    filters: Optional[SearchFilters] = None
+    filters: SearchFilters | None = None
 
     def __post_init__(self) -> None:
         if not self.keyword or not self.keyword.strip():
@@ -75,11 +75,11 @@ class VideoMetadata:
     view_count: int
     thumbnails: dict[str, object]
     category_id: str
-    like_count: Optional[int] = None
+    like_count: int | None = None
     """None when the channel has disabled the like counter."""
-    tags: Optional[list[str]] = None
+    tags: list[str] | None = None
     """None when the uploader did not set any tags."""
-    default_language: Optional[str] = None
+    default_language: str | None = None
     """BCP-47 language tag, e.g. 'en'. None when not declared by uploader."""
 
 

--- a/src/mimesis/video_discovery/domain/models.py
+++ b/src/mimesis/video_discovery/domain/models.py
@@ -39,10 +39,7 @@ class SearchFilters:
     _VALID_DURATIONS: ClassVar[frozenset[str]] = frozenset({"short", "medium", "long"})
 
     def __post_init__(self) -> None:
-        if (
-            self.video_duration is not None
-            and self.video_duration not in self._VALID_DURATIONS
-        ):
+        if self.video_duration is not None and self.video_duration not in self._VALID_DURATIONS:
             raise ValueError(
                 f"video_duration must be one of {sorted(self._VALID_DURATIONS)!r}, "
                 f"got: {self.video_duration!r}"
@@ -111,8 +108,7 @@ class SearchJob:
     def mark_running(self) -> None:
         if self.status != SearchJobStatus.PENDING:
             raise ValueError(
-                f"Cannot transition to RUNNING from {self.status}. "
-                "Job must be in PENDING state."
+                f"Cannot transition to RUNNING from {self.status}. " "Job must be in PENDING state."
             )
         self.status = SearchJobStatus.RUNNING
 

--- a/src/mimesis/video_discovery/infra/video_event_publisher.py
+++ b/src/mimesis/video_discovery/infra/video_event_publisher.py
@@ -52,9 +52,7 @@ class ServiceBusEventPublisher(EventPublisherPort):
         )
         try:
             self._sender.send_messages(message)
-            logger.debug(
-                "VideoDiscovered sent to Service Bus | video_id=%s", event.video_id
-            )
+            logger.debug("VideoDiscovered sent to Service Bus | video_id=%s", event.video_id)
         except Exception as exc:
             raise EventPublisherError(
                 f"Failed to publish VideoDiscovered for video_id={event.video_id!r}: {exc}"

--- a/src/mimesis/video_discovery/infra/youtube_api_client.py
+++ b/src/mimesis/video_discovery/infra/youtube_api_client.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
+from typing import Any, cast
 
-from googleapiclient.discovery import build  # type: ignore[import-untyped]
-from googleapiclient.errors import HttpError  # type: ignore[import-untyped]
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
 
 from mimesis.video_discovery.domain.exceptions import (
     QuotaExceededException,
@@ -32,19 +33,24 @@ def _safe_int(value: object) -> int | None:
     return int(str(value)) if value is not None else None
 
 
-def _parse_metadata(item: dict[str, object]) -> tuple[str, VideoMetadata]:
+def _parse_metadata(item: dict[str, Any]) -> tuple[str, VideoMetadata]:
     """Extract videoId and VideoMetadata from a ``videos.list`` resource item."""
     video_id: str = str(item["id"])
-    snippet: dict[str, object] = item.get("snippet", {})  # type: ignore[assignment]
-    details: dict[str, object] = item.get("contentDetails", {})  # type: ignore[assignment]
-    stats: dict[str, object] = item.get("statistics", {})  # type: ignore[assignment]
+    snippet = cast(dict[str, Any], item.get("snippet", {}))
+    details = cast(dict[str, Any], item.get("contentDetails", {}))
+    stats = cast(dict[str, Any], item.get("statistics", {}))
 
     published_at_raw = str(snippet.get("publishedAt", ""))
     published_at = datetime.fromisoformat(published_at_raw.replace("Z", "+00:00"))
 
-    thumbnails = snippet.get("thumbnails", {})
+    thumbnails = cast(dict[str, object], snippet.get("thumbnails", {}))
     tags_raw = snippet.get("tags")
-    tags: list[str] | None = list(tags_raw) if tags_raw else None  # type: ignore[arg-type]
+    tags: list[str] | None = None
+    if isinstance(tags_raw, list):
+        tags = [str(tag) for tag in tags_raw]
+
+    default_language_raw = snippet.get("defaultLanguage")
+    default_language = str(default_language_raw) if default_language_raw is not None else None
 
     metadata = VideoMetadata(
         title=str(snippet.get("title", "")),
@@ -55,10 +61,10 @@ def _parse_metadata(item: dict[str, object]) -> tuple[str, VideoMetadata]:
         duration=str(details.get("duration", "")),
         view_count=_safe_int(stats.get("viewCount")) or 0,
         like_count=_safe_int(stats.get("likeCount")),
-        thumbnails=thumbnails,  # type: ignore[arg-type]
+        thumbnails=thumbnails,
         tags=tags,
         category_id=str(snippet.get("categoryId", "")),
-        default_language=snippet.get("defaultLanguage") and str(snippet["defaultLanguage"]),
+        default_language=default_language,
     )
     return video_id, metadata
 
@@ -108,18 +114,19 @@ class YouTubeApiClient(YouTubeApiPort):
                 self._service.search().list(**search_kwargs).execute()
             )
         except HttpError as exc:
-            if exc.resp.status == 403:  # type: ignore[union-attr]
+            if exc.resp.status == 403:
                 raise QuotaExceededException(str(exc)) from exc
             raise YouTubeApiError(str(exc)) from exc
 
-        items: list[dict[str, object]] = search_response.get("items", [])  # type: ignore[assignment]
-        next_page_token: str | None = search_response.get("nextPageToken")  # type: ignore[assignment]
+        items = cast(list[dict[str, Any]], search_response.get("items", []))
+        next_page_token_raw = search_response.get("nextPageToken")
+        next_page_token = str(next_page_token_raw) if next_page_token_raw is not None else None
 
         if not items:
             return SearchPage(video_metadatas=[], next_page_token=None)
 
         # ── 2. videos.list (batch) ───────────────────────────────────────────
-        video_ids = ",".join(str(item["id"]["videoId"]) for item in items)  # type: ignore[index]
+        video_ids = ",".join(str(item["id"]["videoId"]) for item in items)
 
         try:
             videos_response: dict[str, object] = (
@@ -128,11 +135,11 @@ class YouTubeApiClient(YouTubeApiPort):
                 .execute()
             )
         except HttpError as exc:
-            if exc.resp.status == 403:  # type: ignore[union-attr]
+            if exc.resp.status == 403:
                 raise QuotaExceededException(str(exc)) from exc
             raise YouTubeApiError(str(exc)) from exc
 
-        video_items: list[dict[str, object]] = videos_response.get("items", [])  # type: ignore[assignment]
+        video_items = cast(list[dict[str, Any]], videos_response.get("items", []))
         results = [_parse_metadata(item) for item in video_items]
 
         logger.debug(

--- a/src/mimesis/video_discovery/infra/youtube_api_client.py
+++ b/src/mimesis/video_discovery/infra/youtube_api_client.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Optional
 
 from googleapiclient.discovery import build  # type: ignore[import-untyped]
 from googleapiclient.errors import HttpError  # type: ignore[import-untyped]
@@ -28,7 +27,7 @@ _YT_API_SERVICE = "youtube"
 _YT_API_VERSION = "v3"
 
 
-def _safe_int(value: object) -> Optional[int]:
+def _safe_int(value: object) -> int | None:
     """Convert a YouTube statistics string value to int; return None if absent."""
     return int(str(value)) if value is not None else None
 
@@ -45,7 +44,7 @@ def _parse_metadata(item: dict[str, object]) -> tuple[str, VideoMetadata]:
 
     thumbnails = snippet.get("thumbnails", {})
     tags_raw = snippet.get("tags")
-    tags: Optional[list[str]] = list(tags_raw) if tags_raw else None  # type: ignore[arg-type]
+    tags: list[str] | None = list(tags_raw) if tags_raw else None  # type: ignore[arg-type]
 
     metadata = VideoMetadata(
         title=str(snippet.get("title", "")),
@@ -79,7 +78,7 @@ class YouTubeApiClient(YouTubeApiPort):
         self,
         query: SearchQuery,
         page_size: int,
-        page_token: Optional[str] = None,
+        page_token: str | None = None,
     ) -> SearchPage:
         filters = query.filters
 
@@ -114,7 +113,7 @@ class YouTubeApiClient(YouTubeApiPort):
             raise YouTubeApiError(str(exc)) from exc
 
         items: list[dict[str, object]] = search_response.get("items", [])  # type: ignore[assignment]
-        next_page_token: Optional[str] = search_response.get("nextPageToken")  # type: ignore[assignment]
+        next_page_token: str | None = search_response.get("nextPageToken")  # type: ignore[assignment]
 
         if not items:
             return SearchPage(video_metadatas=[], next_page_token=None)

--- a/src/mimesis/video_discovery/infra/youtube_api_client.py
+++ b/src/mimesis/video_discovery/infra/youtube_api_client.py
@@ -95,8 +95,8 @@ class YouTubeApiClient(YouTubeApiPort):
             if filters.language:
                 search_kwargs["relevanceLanguage"] = filters.language
             if filters.published_after:
-                search_kwargs["publishedAfter"] = (
-                    filters.published_after.strftime("%Y-%m-%dT%H:%M:%SZ")
+                search_kwargs["publishedAfter"] = filters.published_after.strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
                 )
             if filters.video_duration:
                 search_kwargs["videoDuration"] = filters.video_duration
@@ -119,9 +119,7 @@ class YouTubeApiClient(YouTubeApiPort):
             return SearchPage(video_metadatas=[], next_page_token=None)
 
         # ── 2. videos.list (batch) ───────────────────────────────────────────
-        video_ids = ",".join(
-            str(item["id"]["videoId"]) for item in items  # type: ignore[index]
-        )
+        video_ids = ",".join(str(item["id"]["videoId"]) for item in items)  # type: ignore[index]
 
         try:
             videos_response: dict[str, object] = (

--- a/src/mimesis/video_discovery/ports/youtube_api_port.py
+++ b/src/mimesis/video_discovery/ports/youtube_api_port.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Optional
 
 from mimesis.video_discovery.domain.models import SearchQuery, VideoMetadata
 
@@ -20,7 +19,7 @@ class SearchPage:
     video_metadatas: list[tuple[str, VideoMetadata]]
     """List of (videoId, VideoMetadata) tuples for this page."""
 
-    next_page_token: Optional[str]
+    next_page_token: str | None
     """Opaque cursor to pass on the next call, or None when exhausted."""
 
 
@@ -32,7 +31,7 @@ class YouTubeApiPort(ABC):
         self,
         query: SearchQuery,
         page_size: int,
-        page_token: Optional[str] = None,
+        page_token: str | None = None,
     ) -> SearchPage:
         """Fetch a single page of search results.
 

--- a/src/mimesis/video_ingestion/__init__.py
+++ b/src/mimesis/video_ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""BC-02 Video Ingestion bounded context."""

--- a/src/mimesis/video_ingestion/application/__init__.py
+++ b/src/mimesis/video_ingestion/application/__init__.py
@@ -1,0 +1,1 @@
+"""Application services for BC-02 Video Ingestion."""

--- a/src/mimesis/video_ingestion/application/video_ingestion_service.py
+++ b/src/mimesis/video_ingestion/application/video_ingestion_service.py
@@ -75,9 +75,7 @@ class VideoIngestionService:
 
             complete = self._artifact_store.artifacts_complete(paths)
             if not complete:
-                raise RuntimeError(
-                    "Artifact completeness validation failed after upload."
-                )
+                raise RuntimeError("Artifact completeness validation failed after upload.")
 
             self._ledger.upsert(payload.video_id, IngestionStatus.COMPLETED)
 
@@ -107,7 +105,6 @@ class VideoIngestionService:
             raise
 
 
-
 def parse_video_discovered_payload(raw: str) -> VideoDiscoveredPayload:
     """Validate and parse queue payload into a typed object."""
     try:
@@ -118,9 +115,7 @@ def parse_video_discovered_payload(raw: str) -> VideoDiscoveredPayload:
     required = ["search_job_id", "video_id", "occurred_at", "metadata"]
     missing = [key for key in required if key not in data]
     if missing:
-        raise InvalidVideoDiscoveredEventError(
-            f"Missing required fields: {', '.join(missing)}"
-        )
+        raise InvalidVideoDiscoveredEventError(f"Missing required fields: {', '.join(missing)}")
 
     if not isinstance(data["metadata"], dict):
         raise InvalidVideoDiscoveredEventError("metadata must be an object")
@@ -128,9 +123,7 @@ def parse_video_discovered_payload(raw: str) -> VideoDiscoveredPayload:
     try:
         occurred_at = datetime.fromisoformat(str(data["occurred_at"]).replace("Z", "+00:00"))
     except ValueError as exc:
-        raise InvalidVideoDiscoveredEventError(
-            "occurred_at must be an ISO-8601 datetime"
-        ) from exc
+        raise InvalidVideoDiscoveredEventError("occurred_at must be an ISO-8601 datetime") from exc
 
     return VideoDiscoveredPayload(
         search_job_id=str(data["search_job_id"]),
@@ -138,7 +131,6 @@ def parse_video_discovered_payload(raw: str) -> VideoDiscoveredPayload:
         occurred_at=occurred_at,
         metadata=data["metadata"],
     )
-
 
 
 def _build_ingestion_metadata_json(

--- a/src/mimesis/video_ingestion/application/video_ingestion_service.py
+++ b/src/mimesis/video_ingestion/application/video_ingestion_service.py
@@ -1,0 +1,162 @@
+"""Application service for BC-02 Video Ingestion."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+
+from mimesis.video_ingestion.domain.events import VideoIngested
+from mimesis.video_ingestion.domain.exceptions import InvalidVideoDiscoveredEventError
+from mimesis.video_ingestion.domain.models import (
+    ArtifactPaths,
+    IngestionResult,
+    IngestionStatus,
+    VideoDiscoveredPayload,
+    canonical_paths,
+    utcnow,
+)
+from mimesis.video_ingestion.ports.artifact_store_port import ArtifactStorePort
+from mimesis.video_ingestion.ports.ingested_event_publisher_port import IngestedEventPublisherPort
+from mimesis.video_ingestion.ports.ingestion_ledger_port import IngestionLedgerPort
+from mimesis.video_ingestion.ports.media_processor_port import MediaProcessorPort
+
+logger = logging.getLogger(__name__)
+
+
+class VideoIngestionService:
+    """Processes one VideoDiscovered event and emits VideoIngested on success."""
+
+    def __init__(
+        self,
+        *,
+        artifact_store: ArtifactStorePort,
+        ledger: IngestionLedgerPort,
+        media_processor: MediaProcessorPort,
+        event_publisher: IngestedEventPublisherPort,
+    ) -> None:
+        self._artifact_store = artifact_store
+        self._ledger = ledger
+        self._media_processor = media_processor
+        self._event_publisher = event_publisher
+
+    def ingest_discovered_video(self, payload: VideoDiscoveredPayload) -> IngestionResult:
+        paths = canonical_paths(payload.video_id)
+        record = self._ledger.get(payload.video_id)
+
+        if (
+            record is not None
+            and record.status == IngestionStatus.COMPLETED
+            and self._artifact_store.artifacts_complete(paths)
+        ):
+            logger.info("Skipping already-ingested video | video_id=%s", payload.video_id)
+            return IngestionResult(
+                video_id=payload.video_id,
+                status=IngestionStatus.COMPLETED,
+                artifacts_complete=True,
+                skipped_as_duplicate=True,
+            )
+
+        self._ledger.upsert(payload.video_id, IngestionStatus.PROCESSING)
+        ingested_at = utcnow()
+
+        try:
+            source_video = self._media_processor.download_source_video(payload.youtube_url)
+            video_url = self._artifact_store.upload_video(paths.video_path, source_video)
+
+            audio_mp3 = self._media_processor.extract_audio_mp3(source_video)
+            audio_url = self._artifact_store.upload_audio(paths.audio_path, audio_mp3)
+
+            metadata_json = _build_ingestion_metadata_json(payload, ingested_at, paths)
+            metadata_url = self._artifact_store.upload_metadata(
+                paths.metadata_path,
+                metadata_json,
+            )
+
+            complete = self._artifact_store.artifacts_complete(paths)
+            if not complete:
+                raise RuntimeError(
+                    "Artifact completeness validation failed after upload."
+                )
+
+            self._ledger.upsert(payload.video_id, IngestionStatus.COMPLETED)
+
+            event = VideoIngested.build(
+                search_job_id=payload.search_job_id,
+                video_id=payload.video_id,
+                ingested_at=ingested_at,
+                paths=paths,
+                audio_url=audio_url,
+                metadata_url=metadata_url,
+                video_url=video_url,
+            )
+            self._event_publisher.publish(event)
+
+            return IngestionResult(
+                video_id=payload.video_id,
+                status=IngestionStatus.COMPLETED,
+                artifacts_complete=True,
+                skipped_as_duplicate=False,
+            )
+        except Exception as exc:
+            self._ledger.upsert(
+                payload.video_id,
+                IngestionStatus.FAILED,
+                failure_reason=str(exc),
+            )
+            raise
+
+
+
+def parse_video_discovered_payload(raw: str) -> VideoDiscoveredPayload:
+    """Validate and parse queue payload into a typed object."""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise InvalidVideoDiscoveredEventError("Invalid JSON payload") from exc
+
+    required = ["search_job_id", "video_id", "occurred_at", "metadata"]
+    missing = [key for key in required if key not in data]
+    if missing:
+        raise InvalidVideoDiscoveredEventError(
+            f"Missing required fields: {', '.join(missing)}"
+        )
+
+    if not isinstance(data["metadata"], dict):
+        raise InvalidVideoDiscoveredEventError("metadata must be an object")
+
+    try:
+        occurred_at = datetime.fromisoformat(str(data["occurred_at"]).replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise InvalidVideoDiscoveredEventError(
+            "occurred_at must be an ISO-8601 datetime"
+        ) from exc
+
+    return VideoDiscoveredPayload(
+        search_job_id=str(data["search_job_id"]),
+        video_id=str(data["video_id"]),
+        occurred_at=occurred_at,
+        metadata=data["metadata"],
+    )
+
+
+
+def _build_ingestion_metadata_json(
+    payload: VideoDiscoveredPayload,
+    ingested_at: datetime,
+    paths: ArtifactPaths,
+) -> bytes:
+    body = {
+        "video_id": payload.video_id,
+        "search_job_id": payload.search_job_id,
+        "discovered_at": payload.occurred_at.isoformat(),
+        "ingested_at": ingested_at.isoformat(),
+        "source": {
+            "youtube_url": payload.youtube_url,
+            "video_path": paths.video_path,
+            "audio_path": paths.audio_path,
+            "metadata_path": paths.metadata_path,
+        },
+        "metadata": payload.metadata,
+    }
+    return json.dumps(body, ensure_ascii=False).encode("utf-8")

--- a/src/mimesis/video_ingestion/config.py
+++ b/src/mimesis/video_ingestion/config.py
@@ -1,0 +1,32 @@
+"""Runtime configuration for BC-02 Video Ingestion."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VideoIngestionConfig:
+    storage_account_url: str
+    ingestion_ledger_table: str
+    service_bus_namespace: str
+    video_ingested_queue: str
+    app_insights_connection_string: str
+
+    @classmethod
+    def from_env(cls) -> VideoIngestionConfig:
+        return cls(
+            storage_account_url=_require("MIMESIS_STORAGE_ACCOUNT_URL").replace(".table.", ".blob."),
+            ingestion_ledger_table=os.getenv("MIMESIS_INGESTION_LEDGER_TABLE", "ingestionLedger"),
+            service_bus_namespace=_require("MIMESIS_SERVICE_BUS_NAMESPACE"),
+            video_ingested_queue=os.getenv("MIMESIS_SERVICE_BUS_INGESTED_QUEUE", "sb-queue-video-ingested"),
+            app_insights_connection_string=_require("MIMESIS_APP_INSIGHTS_CONNECTION_STRING"),
+        )
+
+
+def _require(key: str) -> str:
+    value = os.getenv(key)
+    if not value:
+        raise RuntimeError(f"Required environment variable '{key}' is not set.")
+    return value

--- a/src/mimesis/video_ingestion/config.py
+++ b/src/mimesis/video_ingestion/config.py
@@ -17,10 +17,14 @@ class VideoIngestionConfig:
     @classmethod
     def from_env(cls) -> VideoIngestionConfig:
         return cls(
-            storage_account_url=_require("MIMESIS_STORAGE_ACCOUNT_URL").replace(".table.", ".blob."),
+            storage_account_url=_require("MIMESIS_STORAGE_ACCOUNT_URL").replace(
+                ".table.", ".blob."
+            ),
             ingestion_ledger_table=os.getenv("MIMESIS_INGESTION_LEDGER_TABLE", "ingestionLedger"),
             service_bus_namespace=_require("MIMESIS_SERVICE_BUS_NAMESPACE"),
-            video_ingested_queue=os.getenv("MIMESIS_SERVICE_BUS_INGESTED_QUEUE", "sb-queue-video-ingested"),
+            video_ingested_queue=os.getenv(
+                "MIMESIS_SERVICE_BUS_INGESTED_QUEUE", "sb-queue-video-ingested"
+            ),
             app_insights_connection_string=_require("MIMESIS_APP_INSIGHTS_CONNECTION_STRING"),
         )
 

--- a/src/mimesis/video_ingestion/domain/__init__.py
+++ b/src/mimesis/video_ingestion/domain/__init__.py
@@ -1,0 +1,1 @@
+"""Domain models and events for BC-02 Video Ingestion."""

--- a/src/mimesis/video_ingestion/domain/events.py
+++ b/src/mimesis/video_ingestion/domain/events.py
@@ -1,0 +1,63 @@
+"""Domain events for BC-02 Video Ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from mimesis.video_ingestion.domain.models import ArtifactPaths
+
+
+@dataclass(frozen=True)
+class VideoIngested:
+    """Event emitted once video/audio/metadata artifacts are durably available."""
+
+    schema_version: str
+    search_job_id: str
+    video_id: str
+    ingested_at: datetime
+    audio_url: str
+    audio_path: str
+    metadata_url: str
+    metadata_path: str
+    video_url: str
+    video_path: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        search_job_id: str,
+        video_id: str,
+        ingested_at: datetime,
+        paths: ArtifactPaths,
+        audio_url: str,
+        metadata_url: str,
+        video_url: str,
+    ) -> VideoIngested:
+        return cls(
+            schema_version="v1",
+            search_job_id=search_job_id,
+            video_id=video_id,
+            ingested_at=ingested_at,
+            audio_url=audio_url,
+            audio_path=paths.audio_path,
+            metadata_url=metadata_url,
+            metadata_path=paths.metadata_path,
+            video_url=video_url,
+            video_path=paths.video_path,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "search_job_id": self.search_job_id,
+            "video_id": self.video_id,
+            "ingested_at": self.ingested_at.isoformat(),
+            "audio_url": self.audio_url,
+            "audio_path": self.audio_path,
+            "metadata_url": self.metadata_url,
+            "metadata_path": self.metadata_path,
+            "video_url": self.video_url,
+            "video_path": self.video_path,
+        }

--- a/src/mimesis/video_ingestion/domain/exceptions.py
+++ b/src/mimesis/video_ingestion/domain/exceptions.py
@@ -1,0 +1,25 @@
+"""Domain exceptions for BC-02 Video Ingestion."""
+
+
+class VideoIngestionError(Exception):
+    """Base class for all BC-02 ingestion errors."""
+
+
+class InvalidVideoDiscoveredEventError(VideoIngestionError):
+    """Raised when the incoming VideoDiscovered payload is malformed."""
+
+
+class IngestionLedgerError(VideoIngestionError):
+    """Raised when ingestion ledger operations fail."""
+
+
+class ArtifactStoreError(VideoIngestionError):
+    """Raised when artifact upload/read checks fail."""
+
+
+class MediaProcessingError(VideoIngestionError):
+    """Raised when media download or audio extraction fails."""
+
+
+class IngestedEventPublisherError(VideoIngestionError):
+    """Raised when publishing VideoIngested to Service Bus fails."""

--- a/src/mimesis/video_ingestion/domain/models.py
+++ b/src/mimesis/video_ingestion/domain/models.py
@@ -1,0 +1,70 @@
+"""Domain models for BC-02 Video Ingestion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+
+
+class IngestionStatus(StrEnum):
+    PENDING = "Pending"
+    PROCESSING = "Processing"
+    COMPLETED = "Completed"
+    FAILED = "Failed"
+
+
+@dataclass(frozen=True)
+class ArtifactPaths:
+    """Canonical Blob paths for one video ingestion job."""
+
+    video_path: str
+    audio_path: str
+    metadata_path: str
+
+
+@dataclass(frozen=True)
+class VideoDiscoveredPayload:
+    """Input event payload consumed from sb-queue-video-discovered."""
+
+    search_job_id: str
+    video_id: str
+    occurred_at: datetime
+    metadata: dict[str, object]
+
+    @property
+    def youtube_url(self) -> str:
+        return f"https://www.youtube.com/watch?v={self.video_id}"
+
+
+@dataclass(frozen=True)
+class IngestionRecord:
+    """Idempotency state persisted in Azure Table Storage."""
+
+    video_id: str
+    status: IngestionStatus
+    processed_at: datetime | None = None
+    failure_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class IngestionResult:
+    """Application-service outcome for one message processing attempt."""
+
+    video_id: str
+    status: IngestionStatus
+    artifacts_complete: bool
+    skipped_as_duplicate: bool
+
+
+def canonical_paths(video_id: str) -> ArtifactPaths:
+    """Build deterministic artifact paths for a video."""
+    return ArtifactPaths(
+        video_path=f"raw-videos/{video_id}/source.mp4",
+        audio_path=f"extracted-audio/{video_id}/audio.mp3",
+        metadata_path=f"video-metadata/{video_id}/metadata.json",
+    )
+
+
+def utcnow() -> datetime:
+    return datetime.now(UTC)

--- a/src/mimesis/video_ingestion/function_app.py
+++ b/src/mimesis/video_ingestion/function_app.py
@@ -1,0 +1,79 @@
+"""Azure Functions Service Bus trigger for BC-02 Video Ingestion."""
+
+from __future__ import annotations
+
+import logging
+
+import azure.functions as func
+
+from mimesis.shared.observability import configure_observability
+from mimesis.video_ingestion.application.video_ingestion_service import (
+    VideoIngestionService,
+    parse_video_discovered_payload,
+)
+from mimesis.video_ingestion.config import VideoIngestionConfig
+from mimesis.video_ingestion.domain.exceptions import (
+    InvalidVideoDiscoveredEventError,
+    VideoIngestionError,
+)
+from mimesis.video_ingestion.infra.blob_artifact_store import BlobArtifactStore
+from mimesis.video_ingestion.infra.ingestion_ledger import TableIngestionLedger
+from mimesis.video_ingestion.infra.media_processor import PytubefixMediaProcessor
+from mimesis.video_ingestion.infra.video_ingested_event_publisher import (
+    ServiceBusVideoIngestedPublisher,
+)
+
+logger = logging.getLogger(__name__)
+
+app = func.FunctionApp()
+
+_config = VideoIngestionConfig.from_env()
+configure_observability(
+    connection_string=_config.app_insights_connection_string,
+    service_name="mimesis-video-ingestion",
+)
+
+_service = VideoIngestionService(
+    artifact_store=BlobArtifactStore(account_url=_config.storage_account_url),
+    ledger=TableIngestionLedger(
+        account_url=_config.storage_account_url.replace(".blob.", ".table."),
+        table_name=_config.ingestion_ledger_table,
+    ),
+    media_processor=PytubefixMediaProcessor(),
+    event_publisher=ServiceBusVideoIngestedPublisher(
+        fully_qualified_namespace=_config.service_bus_namespace,
+        queue_name=_config.video_ingested_queue,
+    ),
+)
+
+
+@app.function_name(name="VideoIngestion")
+@app.service_bus_queue_trigger(
+    arg_name="message",
+    queue_name="sb-queue-video-discovered",
+    connection="MIMESIS_SERVICE_BUS",
+)
+def video_ingestion(message: func.ServiceBusMessage) -> None:
+    """Consume VideoDiscovered and persist durable artifacts."""
+    raw = message.get_body().decode("utf-8")
+    message_id = message.message_id
+
+    try:
+        payload = parse_video_discovered_payload(raw)
+        result = _service.ingest_discovered_video(payload)
+        logger.info(
+            "Video ingestion completed | message_id=%s video_id=%s skipped_duplicate=%s",
+            message_id,
+            payload.video_id,
+            result.skipped_as_duplicate,
+        )
+    except InvalidVideoDiscoveredEventError:
+        # Invalid schema is treated as a non-retryable poison message.
+        logger.exception("Invalid VideoDiscovered payload | message_id=%s", message_id)
+        raise
+    except VideoIngestionError:
+        logger.exception("Ingestion failed | message_id=%s", message_id)
+        raise
+    except Exception:
+        logger.exception("Unexpected ingestion failure | message_id=%s", message_id)
+        raise

--- a/src/mimesis/video_ingestion/infra/__init__.py
+++ b/src/mimesis/video_ingestion/infra/__init__.py
@@ -1,0 +1,1 @@
+"""Infrastructure adapters for BC-02 Video Ingestion."""

--- a/src/mimesis/video_ingestion/infra/blob_artifact_store.py
+++ b/src/mimesis/video_ingestion/infra/blob_artifact_store.py
@@ -1,0 +1,66 @@
+"""Azure Blob Storage adapter for BC-02 ingestion artifacts."""
+
+from __future__ import annotations
+
+from azure.identity import DefaultAzureCredential
+from azure.storage.blob import BlobServiceClient
+
+from mimesis.video_ingestion.domain.exceptions import ArtifactStoreError
+from mimesis.video_ingestion.domain.models import ArtifactPaths
+from mimesis.video_ingestion.ports.artifact_store_port import ArtifactStorePort
+
+
+class BlobArtifactStore(ArtifactStorePort):
+    """Stores artifacts in Blob Storage containers and checks completeness."""
+
+    def __init__(self, account_url: str) -> None:
+        credential = DefaultAzureCredential()
+        self._service = BlobServiceClient(account_url=account_url, credential=credential)
+
+    def artifacts_complete(self, paths: ArtifactPaths) -> bool:
+        return (
+            self._exists(paths.video_path)
+            and self._exists(paths.audio_path)
+            and self._exists(paths.metadata_path)
+        )
+
+    def upload_video(self, path: str, content: bytes) -> str:
+        return self._upload(path, content, "video/mp4")
+
+    def upload_audio(self, path: str, content: bytes) -> str:
+        return self._upload(path, content, "audio/mpeg")
+
+    def upload_metadata(self, path: str, content: bytes) -> str:
+        return self._upload(path, content, "application/json")
+
+    def _upload(self, canonical_path: str, content: bytes, content_type: str) -> str:
+        container, blob = _split_path(canonical_path)
+        try:
+            container_client = self._service.get_container_client(container)
+            container_client.create_container()
+        except Exception:
+            # Ignore create errors because the container may already exist.
+            pass
+
+        try:
+            blob_client = self._service.get_blob_client(container=container, blob=blob)
+            blob_client.upload_blob(content, overwrite=True, content_type=content_type)
+            return blob_client.url
+        except Exception as exc:
+            raise ArtifactStoreError(f"Failed to upload artifact at '{canonical_path}': {exc}") from exc
+
+    def _exists(self, canonical_path: str) -> bool:
+        container, blob = _split_path(canonical_path)
+        try:
+            blob_client = self._service.get_blob_client(container=container, blob=blob)
+            return blob_client.exists()
+        except Exception as exc:
+            raise ArtifactStoreError(f"Failed blob existence check for '{canonical_path}': {exc}") from exc
+
+
+
+def _split_path(path: str) -> tuple[str, str]:
+    parts = path.split("/", 1)
+    if len(parts) != 2:
+        raise ArtifactStoreError(f"Invalid canonical path: '{path}'")
+    return parts[0], parts[1]

--- a/src/mimesis/video_ingestion/infra/blob_artifact_store.py
+++ b/src/mimesis/video_ingestion/infra/blob_artifact_store.py
@@ -47,7 +47,9 @@ class BlobArtifactStore(ArtifactStorePort):
             blob_client.upload_blob(content, overwrite=True, content_type=content_type)
             return blob_client.url
         except Exception as exc:
-            raise ArtifactStoreError(f"Failed to upload artifact at '{canonical_path}': {exc}") from exc
+            raise ArtifactStoreError(
+                f"Failed to upload artifact at '{canonical_path}': {exc}"
+            ) from exc
 
     def _exists(self, canonical_path: str) -> bool:
         container, blob = _split_path(canonical_path)
@@ -55,8 +57,9 @@ class BlobArtifactStore(ArtifactStorePort):
             blob_client = self._service.get_blob_client(container=container, blob=blob)
             return blob_client.exists()
         except Exception as exc:
-            raise ArtifactStoreError(f"Failed blob existence check for '{canonical_path}': {exc}") from exc
-
+            raise ArtifactStoreError(
+                f"Failed blob existence check for '{canonical_path}': {exc}"
+            ) from exc
 
 
 def _split_path(path: str) -> tuple[str, str]:

--- a/src/mimesis/video_ingestion/infra/ingestion_ledger.py
+++ b/src/mimesis/video_ingestion/infra/ingestion_ledger.py
@@ -27,7 +27,9 @@ class TableIngestionLedger(IngestionLedgerPort):
         except ResourceNotFoundError:
             return None
         except Exception as exc:
-            raise IngestionLedgerError(f"Failed to read ingestion ledger for '{video_id}': {exc}") from exc
+            raise IngestionLedgerError(
+                f"Failed to read ingestion ledger for '{video_id}': {exc}"
+            ) from exc
 
         status_raw = str(entity.get("status", IngestionStatus.PENDING.value))
         try:
@@ -50,7 +52,9 @@ class TableIngestionLedger(IngestionLedgerPort):
             failure_reason=entity.get("failure_reason"),
         )
 
-    def upsert(self, video_id: str, status: IngestionStatus, failure_reason: str | None = None) -> None:
+    def upsert(
+        self, video_id: str, status: IngestionStatus, failure_reason: str | None = None
+    ) -> None:
         entity = {
             "PartitionKey": "video",
             "RowKey": video_id,
@@ -61,4 +65,6 @@ class TableIngestionLedger(IngestionLedgerPort):
         try:
             self._client.upsert_entity(mode=UpdateMode.MERGE, entity=entity)
         except Exception as exc:
-            raise IngestionLedgerError(f"Failed to upsert ingestion ledger for '{video_id}': {exc}") from exc
+            raise IngestionLedgerError(
+                f"Failed to upsert ingestion ledger for '{video_id}': {exc}"
+            ) from exc

--- a/src/mimesis/video_ingestion/infra/ingestion_ledger.py
+++ b/src/mimesis/video_ingestion/infra/ingestion_ledger.py
@@ -1,0 +1,64 @@
+"""Azure Table Storage ingestion ledger adapter."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from azure.core.exceptions import ResourceNotFoundError
+from azure.data.tables import TableServiceClient, UpdateMode
+from azure.identity import DefaultAzureCredential
+
+from mimesis.video_ingestion.domain.exceptions import IngestionLedgerError
+from mimesis.video_ingestion.domain.models import IngestionRecord, IngestionStatus
+from mimesis.video_ingestion.ports.ingestion_ledger_port import IngestionLedgerPort
+
+
+class TableIngestionLedger(IngestionLedgerPort):
+    """Maintains ingestion idempotency records keyed by video_id."""
+
+    def __init__(self, account_url: str, table_name: str) -> None:
+        credential = DefaultAzureCredential()
+        service = TableServiceClient(endpoint=account_url, credential=credential)
+        self._client = service.get_table_client(table_name)
+
+    def get(self, video_id: str) -> IngestionRecord | None:
+        try:
+            entity = self._client.get_entity(partition_key="video", row_key=video_id)
+        except ResourceNotFoundError:
+            return None
+        except Exception as exc:
+            raise IngestionLedgerError(f"Failed to read ingestion ledger for '{video_id}': {exc}") from exc
+
+        status_raw = str(entity.get("status", IngestionStatus.PENDING.value))
+        try:
+            status = IngestionStatus(status_raw)
+        except ValueError:
+            status = IngestionStatus.PENDING
+
+        processed_raw = entity.get("processed_at")
+        processed_at = None
+        if isinstance(processed_raw, str):
+            try:
+                processed_at = datetime.fromisoformat(processed_raw.replace("Z", "+00:00"))
+            except ValueError:
+                processed_at = None
+
+        return IngestionRecord(
+            video_id=video_id,
+            status=status,
+            processed_at=processed_at,
+            failure_reason=entity.get("failure_reason"),
+        )
+
+    def upsert(self, video_id: str, status: IngestionStatus, failure_reason: str | None = None) -> None:
+        entity = {
+            "PartitionKey": "video",
+            "RowKey": video_id,
+            "status": status.value,
+            "processed_at": datetime.now(UTC).isoformat(),
+            "failure_reason": failure_reason,
+        }
+        try:
+            self._client.upsert_entity(mode=UpdateMode.MERGE, entity=entity)
+        except Exception as exc:
+            raise IngestionLedgerError(f"Failed to upsert ingestion ledger for '{video_id}': {exc}") from exc

--- a/src/mimesis/video_ingestion/infra/media_processor.py
+++ b/src/mimesis/video_ingestion/infra/media_processor.py
@@ -1,0 +1,50 @@
+"""Media processing adapter using pytubefix and pydub."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from pydub import AudioSegment
+from pytubefix import YouTube
+
+from mimesis.video_ingestion.domain.exceptions import MediaProcessingError
+from mimesis.video_ingestion.ports.media_processor_port import MediaProcessorPort
+
+
+class PytubefixMediaProcessor(MediaProcessorPort):
+    """Downloads source video and extracts MP3 audio."""
+
+    def download_source_video(self, youtube_url: str) -> bytes:
+        try:
+            with TemporaryDirectory() as tmpdir:
+                yt = YouTube(youtube_url)
+                stream = (
+                    yt.streams.filter(progressive=True, file_extension="mp4")
+                    .order_by("resolution")
+                    .desc()
+                    .first()
+                )
+                if stream is None:
+                    raise MediaProcessingError("No progressive mp4 stream available.")
+
+                output_path = Path(tmpdir)
+                downloaded = stream.download(output_path=str(output_path), filename="source.mp4")
+                return Path(downloaded).read_bytes()
+        except MediaProcessingError:
+            raise
+        except Exception as exc:
+            raise MediaProcessingError(f"Failed to download source video: {exc}") from exc
+
+    def extract_audio_mp3(self, source_video_bytes: bytes) -> bytes:
+        try:
+            with TemporaryDirectory() as tmpdir:
+                video_path = Path(tmpdir) / "source.mp4"
+                audio_path = Path(tmpdir) / "audio.mp3"
+                video_path.write_bytes(source_video_bytes)
+
+                audio = AudioSegment.from_file(video_path, format="mp4")
+                audio.export(audio_path, format="mp3")
+                return audio_path.read_bytes()
+        except Exception as exc:
+            raise MediaProcessingError(f"Failed to extract mp3 audio: {exc}") from exc

--- a/src/mimesis/video_ingestion/infra/video_ingested_event_publisher.py
+++ b/src/mimesis/video_ingestion/infra/video_ingested_event_publisher.py
@@ -1,0 +1,46 @@
+"""Service Bus publisher for VideoIngested events."""
+
+from __future__ import annotations
+
+import json
+
+from azure.identity import DefaultAzureCredential
+from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+from mimesis.video_ingestion.domain.events import VideoIngested
+from mimesis.video_ingestion.domain.exceptions import IngestedEventPublisherError
+from mimesis.video_ingestion.ports.ingested_event_publisher_port import IngestedEventPublisherPort
+
+
+class ServiceBusVideoIngestedPublisher(IngestedEventPublisherPort):
+    def __init__(self, fully_qualified_namespace: str, queue_name: str) -> None:
+        credential = DefaultAzureCredential()
+        self._client = ServiceBusClient(
+            fully_qualified_namespace=fully_qualified_namespace,
+            credential=credential,
+        )
+        self._sender = self._client.get_queue_sender(queue_name=queue_name)
+
+    def publish(self, event: VideoIngested) -> None:
+        body = json.dumps(event.to_dict(), ensure_ascii=False)
+        message = ServiceBusMessage(
+            body=body,
+            content_type="application/json",
+            message_id=event.video_id,
+        )
+        try:
+            self._sender.send_messages(message)
+        except Exception as exc:
+            raise IngestedEventPublisherError(
+                f"Failed to publish VideoIngested for '{event.video_id}': {exc}"
+            ) from exc
+
+    def close(self) -> None:
+        self._sender.close()
+        self._client.close()
+
+    def __enter__(self) -> ServiceBusVideoIngestedPublisher:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self.close()

--- a/src/mimesis/video_ingestion/ports/__init__.py
+++ b/src/mimesis/video_ingestion/ports/__init__.py
@@ -1,0 +1,1 @@
+"""Port interfaces for BC-02 Video Ingestion."""

--- a/src/mimesis/video_ingestion/ports/artifact_store_port.py
+++ b/src/mimesis/video_ingestion/ports/artifact_store_port.py
@@ -1,0 +1,23 @@
+"""Port interface for artifact persistence and existence checks."""
+
+from abc import ABC, abstractmethod
+
+from mimesis.video_ingestion.domain.models import ArtifactPaths
+
+
+class ArtifactStorePort(ABC):
+    @abstractmethod
+    def artifacts_complete(self, paths: ArtifactPaths) -> bool:
+        """Return True when video/audio/metadata artifacts all exist."""
+
+    @abstractmethod
+    def upload_video(self, path: str, content: bytes) -> str:
+        """Upload source video bytes and return blob URL."""
+
+    @abstractmethod
+    def upload_audio(self, path: str, content: bytes) -> str:
+        """Upload audio bytes and return blob URL."""
+
+    @abstractmethod
+    def upload_metadata(self, path: str, content: bytes) -> str:
+        """Upload metadata JSON bytes and return blob URL."""

--- a/src/mimesis/video_ingestion/ports/ingested_event_publisher_port.py
+++ b/src/mimesis/video_ingestion/ports/ingested_event_publisher_port.py
@@ -1,0 +1,11 @@
+"""Port interface for publishing VideoIngested events."""
+
+from abc import ABC, abstractmethod
+
+from mimesis.video_ingestion.domain.events import VideoIngested
+
+
+class IngestedEventPublisherPort(ABC):
+    @abstractmethod
+    def publish(self, event: VideoIngested) -> None:
+        """Publish a single VideoIngested event."""

--- a/src/mimesis/video_ingestion/ports/ingestion_ledger_port.py
+++ b/src/mimesis/video_ingestion/ports/ingestion_ledger_port.py
@@ -11,5 +11,7 @@ class IngestionLedgerPort(ABC):
         """Get ledger state for video_id or None if absent."""
 
     @abstractmethod
-    def upsert(self, video_id: str, status: IngestionStatus, failure_reason: str | None = None) -> None:
+    def upsert(
+        self, video_id: str, status: IngestionStatus, failure_reason: str | None = None
+    ) -> None:
         """Create/update ingestion record."""

--- a/src/mimesis/video_ingestion/ports/ingestion_ledger_port.py
+++ b/src/mimesis/video_ingestion/ports/ingestion_ledger_port.py
@@ -1,0 +1,15 @@
+"""Port interface for BC-02 ingestion idempotency ledger."""
+
+from abc import ABC, abstractmethod
+
+from mimesis.video_ingestion.domain.models import IngestionRecord, IngestionStatus
+
+
+class IngestionLedgerPort(ABC):
+    @abstractmethod
+    def get(self, video_id: str) -> IngestionRecord | None:
+        """Get ledger state for video_id or None if absent."""
+
+    @abstractmethod
+    def upsert(self, video_id: str, status: IngestionStatus, failure_reason: str | None = None) -> None:
+        """Create/update ingestion record."""

--- a/src/mimesis/video_ingestion/ports/media_processor_port.py
+++ b/src/mimesis/video_ingestion/ports/media_processor_port.py
@@ -1,0 +1,13 @@
+"""Port interface for source download and audio extraction."""
+
+from abc import ABC, abstractmethod
+
+
+class MediaProcessorPort(ABC):
+    @abstractmethod
+    def download_source_video(self, youtube_url: str) -> bytes:
+        """Download source MP4 bytes from YouTube."""
+
+    @abstractmethod
+    def extract_audio_mp3(self, source_video_bytes: bytes) -> bytes:
+        """Extract MP3 bytes from source MP4 bytes."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -25,7 +25,7 @@ def sample_query_with_filters() -> SearchQuery:
         keyword="storytelling",
         filters=SearchFilters(
             language="en",
-            published_after=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            published_after=datetime(2024, 1, 1, tzinfo=UTC),
             video_duration="medium",
             region_code="GB",
         ),
@@ -39,7 +39,7 @@ def sample_metadata() -> VideoMetadata:
         description="A comprehensive Python tutorial.",
         channel_id="UC_test_channel",
         channel_title="Test Channel",
-        published_at=datetime(2024, 6, 1, tzinfo=timezone.utc),
+        published_at=datetime(2024, 6, 1, tzinfo=UTC),
         duration="PT10M30S",
         view_count=42_000,
         like_count=1_200,

--- a/tests/integration/test_service_bus_integration.py
+++ b/tests/integration/test_service_bus_integration.py
@@ -13,10 +13,9 @@ from __future__ import annotations
 import json
 import os
 import uuid
-from datetime import UTC, datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
-
 from azure.identity import DefaultAzureCredential
 from azure.servicebus import ServiceBusClient
 
@@ -42,7 +41,7 @@ def _sample_event(video_id: str) -> VideoDiscovered:
             description="Created by the integration test suite.",
             channel_id="ch_integration",
             channel_title="Integration Channel",
-            published_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
             duration="PT3M",
             view_count=100,
             like_count=5,
@@ -70,27 +69,26 @@ class TestServiceBusLive:
         credential = DefaultAzureCredential()
         with ServiceBusClient(
             fully_qualified_namespace=_namespace(), credential=credential
-        ) as sb_client:
-            with sb_client.get_queue_receiver(_queue(), max_wait_time=10) as receiver:
-                found = False
-                for msg in receiver:
-                    payload: dict[str, object] = json.loads(str(msg))
-                    if payload.get("video_id") == video_id:
-                        # AC-04: verify self-contained fields
-                        assert "search_job_id" in payload
-                        assert "occurred_at" in payload
-                        metadata = payload.get("metadata", {})
-                        assert metadata.get("title")  # type: ignore[union-attr]
-                        assert metadata.get("channel_id")  # type: ignore[union-attr]
-                        # AC-09: settle (complete) the message
-                        receiver.complete_message(msg)
-                        found = True
-                        break
-                    else:
-                        # Another test message — abandon to avoid interfering
-                        receiver.abandon_message(msg)
+        ) as sb_client, sb_client.get_queue_receiver(_queue(), max_wait_time=10) as receiver:
+            found = False
+            for msg in receiver:
+                payload: dict[str, object] = json.loads(str(msg))
+                if payload.get("video_id") == video_id:
+                    # AC-04: verify self-contained fields
+                    assert "search_job_id" in payload
+                    assert "occurred_at" in payload
+                    metadata = payload.get("metadata", {})
+                    assert metadata.get("title")  # type: ignore[union-attr]
+                    assert metadata.get("channel_id")  # type: ignore[union-attr]
+                    # AC-09: settle (complete) the message
+                    receiver.complete_message(msg)
+                    found = True
+                    break
+                else:
+                    # Another test message — abandon to avoid interfering
+                    receiver.abandon_message(msg)
 
-                assert found, f"Event for video_id={video_id!r} not found on queue"
+            assert found, f"Event for video_id={video_id!r} not found on queue"
 
     def test_ac09_consumer_can_abandon_for_retry(self) -> None:
         """AC-09: Abandoned messages are retried by Service Bus (not consumed once)."""
@@ -103,13 +101,12 @@ class TestServiceBusLive:
         credential = DefaultAzureCredential()
         with ServiceBusClient(
             fully_qualified_namespace=_namespace(), credential=credential
-        ) as sb_client:
-            with sb_client.get_queue_receiver(_queue(), max_wait_time=10) as receiver:
-                for msg in receiver:
-                    payload = json.loads(str(msg))
-                    if payload.get("video_id") == video_id:
-                        # Abandon — message should reappear later
-                        receiver.abandon_message(msg)
-                        break
-                    else:
-                        receiver.abandon_message(msg)
+        ) as sb_client, sb_client.get_queue_receiver(_queue(), max_wait_time=10) as receiver:
+            for msg in receiver:
+                payload = json.loads(str(msg))
+                if payload.get("video_id") == video_id:
+                    # Abandon — message should reappear later
+                    receiver.abandon_message(msg)
+                    break
+                else:
+                    receiver.abandon_message(msg)

--- a/tests/integration/test_service_bus_integration.py
+++ b/tests/integration/test_service_bus_integration.py
@@ -67,9 +67,12 @@ class TestServiceBusLive:
 
         # Consume and settle — AC-09
         credential = DefaultAzureCredential()
-        with ServiceBusClient(
-            fully_qualified_namespace=_namespace(), credential=credential
-        ) as sb_client, sb_client.get_queue_receiver(_queue(), max_wait_time=10) as receiver:
+        with (
+            ServiceBusClient(
+                fully_qualified_namespace=_namespace(), credential=credential
+            ) as sb_client,
+            sb_client.get_queue_receiver(_queue(), max_wait_time=10) as receiver,
+        ):
             found = False
             for msg in receiver:
                 payload: dict[str, object] = json.loads(str(msg))
@@ -99,9 +102,12 @@ class TestServiceBusLive:
             publisher.publish(event)
 
         credential = DefaultAzureCredential()
-        with ServiceBusClient(
-            fully_qualified_namespace=_namespace(), credential=credential
-        ) as sb_client, sb_client.get_queue_receiver(_queue(), max_wait_time=10) as receiver:
+        with (
+            ServiceBusClient(
+                fully_qualified_namespace=_namespace(), credential=credential
+            ) as sb_client,
+            sb_client.get_queue_receiver(_queue(), max_wait_time=10) as receiver,
+        ):
             for msg in receiver:
                 payload = json.loads(str(msg))
                 if payload.get("video_id") == video_id:

--- a/tests/integration/test_youtube_api_integration.py
+++ b/tests/integration/test_youtube_api_integration.py
@@ -11,12 +11,13 @@ Run with: pytest -m integration tests/integration/test_youtube_api_integration.p
 from __future__ import annotations
 
 import os
+from datetime import UTC
 
 import pytest
 
+from mimesis.video_discovery.domain.models import SearchQuery
 from mimesis.video_discovery.infra.secrets_provider import SecretsProvider
 from mimesis.video_discovery.infra.youtube_api_client import YouTubeApiClient
-from mimesis.video_discovery.domain.models import SearchQuery
 
 
 def _get_client() -> YouTubeApiClient:
@@ -49,7 +50,7 @@ class TestYouTubeApiLive:
 
     def test_search_with_all_filters_does_not_raise(self) -> None:
         """AC-08: Filters are forwarded to the API without errors."""
-        from datetime import datetime, timezone
+        from datetime import datetime
 
         from mimesis.video_discovery.domain.models import SearchFilters
 
@@ -59,7 +60,7 @@ class TestYouTubeApiLive:
                 keyword="python",
                 filters=SearchFilters(
                     language="en",
-                    published_after=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                    published_after=datetime(2024, 1, 1, tzinfo=UTC),
                     video_duration="short",
                     region_code="GB",
                 ),

--- a/tests/unit/fakes/fake_youtube_api.py
+++ b/tests/unit/fakes/fake_youtube_api.py
@@ -8,8 +8,7 @@ enabling AC-05 (quota exhaustion) tests.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Optional
+from datetime import UTC, datetime
 
 from mimesis.video_discovery.domain.exceptions import QuotaExceededException
 from mimesis.video_discovery.domain.models import SearchQuery, VideoMetadata
@@ -23,7 +22,7 @@ def _make_metadata(video_id: str) -> VideoMetadata:
         description=f"Description for {video_id}",
         channel_id="ch_test",
         channel_title="Fake Channel",
-        published_at=datetime(2024, 3, 1, tzinfo=timezone.utc),
+        published_at=datetime(2024, 3, 1, tzinfo=UTC),
         duration="PT8M",
         view_count=1_000,
         like_count=50,
@@ -46,7 +45,7 @@ class FakeYouTubeApi(YouTubeApiPort):
     def __init__(
         self,
         pages: list[list[str]],
-        fail_on_page: Optional[int] = None,
+        fail_on_page: int | None = None,
     ) -> None:
         self._pages = pages
         self._fail_on_page = fail_on_page
@@ -56,7 +55,7 @@ class FakeYouTubeApi(YouTubeApiPort):
         self,
         query: SearchQuery,
         page_size: int,
-        page_token: Optional[str] = None,
+        page_token: str | None = None,
     ) -> SearchPage:
         page_index = int(page_token) if page_token else 0
         self.calls.append(
@@ -74,7 +73,7 @@ class FakeYouTubeApi(YouTubeApiPort):
         video_ids = all_video_ids[:page_size]
         results = [(vid, _make_metadata(vid)) for vid in video_ids]
 
-        next_token: Optional[str] = (
+        next_token: str | None = (
             str(page_index + 1) if (page_index + 1) < len(self._pages) else None
         )
         return SearchPage(video_metadatas=results, next_page_token=next_token)

--- a/tests/unit/fakes/fake_youtube_api.py
+++ b/tests/unit/fakes/fake_youtube_api.py
@@ -59,7 +59,12 @@ class FakeYouTubeApi(YouTubeApiPort):
     ) -> SearchPage:
         page_index = int(page_token) if page_token else 0
         self.calls.append(
-            {"query": query, "page_size": page_size, "page_token": page_token, "page_index": page_index}
+            {
+                "query": query,
+                "page_size": page_size,
+                "page_token": page_token,
+                "page_index": page_index,
+            }
         )
 
         if self._fail_on_page is not None and page_index == self._fail_on_page:

--- a/tests/unit/test_domain_models.py
+++ b/tests/unit/test_domain_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 
 from mimesis.video_discovery.domain.models import (
@@ -124,5 +126,5 @@ class TestSearchFilters:
 
     def test_frozen_immutable(self) -> None:
         f = SearchFilters(language="en")
-        with pytest.raises(Exception):  # FrozenInstanceError or AttributeError
+        with pytest.raises(FrozenInstanceError):
             f.language = "pt"  # type: ignore[misc]

--- a/tests/unit/test_video_discovery_service.py
+++ b/tests/unit/test_video_discovery_service.py
@@ -31,9 +31,7 @@ def _make_service(
     youtube = FakeYouTubeApi(pages=pages, fail_on_page=fail_on_page)
     ledger = FakeDiscoveryLedger(preexisting=preexisting or set())
     publisher = FakeEventPublisher()
-    service = VideoDiscoveryService(
-        youtube_api=youtube, ledger=ledger, publisher=publisher
-    )
+    service = VideoDiscoveryService(youtube_api=youtube, ledger=ledger, publisher=publisher)
     return service, youtube, ledger, publisher
 
 
@@ -82,9 +80,7 @@ class TestAC02EmptySearch:
         assert job.new_discoveries == 0
         assert len(publisher.published) == 0
 
-    def test_empty_page_does_not_write_to_ledger(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_empty_page_does_not_write_to_ledger(self, sample_query: SearchQuery) -> None:
         service, _, ledger, _ = _make_service(pages=[[]])
         service.run_search(query=sample_query, max_results=50)
 
@@ -95,9 +91,7 @@ class TestAC02EmptySearch:
 
 
 class TestAC03OneEventPerVideo:
-    def test_n_new_videos_produce_exactly_n_events(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_n_new_videos_produce_exactly_n_events(self, sample_query: SearchQuery) -> None:
         video_ids = ["vid1", "vid2", "vid3"]
         service, _, _, publisher = _make_service(pages=[video_ids])
         job = service.run_search(query=sample_query, max_results=50)
@@ -120,9 +114,7 @@ class TestAC03OneEventPerVideo:
 
 
 class TestAC04SelfContainedPayload:
-    def test_to_dict_contains_required_top_level_keys(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_to_dict_contains_required_top_level_keys(self, sample_query: SearchQuery) -> None:
         service, _, _, publisher = _make_service(pages=[["vid1"]])
         service.run_search(query=sample_query, max_results=50)
 
@@ -132,9 +124,7 @@ class TestAC04SelfContainedPayload:
         assert "occurred_at" in payload
         assert "metadata" in payload
 
-    def test_to_dict_metadata_contains_required_fields(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_to_dict_metadata_contains_required_fields(self, sample_query: SearchQuery) -> None:
         service, _, _, publisher = _make_service(pages=[["vid1"]])
         service.run_search(query=sample_query, max_results=50)
 
@@ -152,9 +142,7 @@ class TestAC04SelfContainedPayload:
         }
         assert required_keys.issubset(metadata.keys())  # type: ignore[union-attr]
 
-    def test_search_job_id_is_serialised_as_string(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_search_job_id_is_serialised_as_string(self, sample_query: SearchQuery) -> None:
         service, _, _, publisher = _make_service(pages=[["vid1"]])
         service.run_search(query=sample_query, max_results=50)
 
@@ -166,9 +154,7 @@ class TestAC04SelfContainedPayload:
 
 
 class TestAC05QuotaExhaustion:
-    def test_quota_on_first_page_marks_job_failed(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_quota_on_first_page_marks_job_failed(self, sample_query: SearchQuery) -> None:
         service, _, _, publisher = _make_service(pages=[[]], fail_on_page=0)
         job = service.run_search(query=sample_query, max_results=50)
 
@@ -190,9 +176,7 @@ class TestAC05QuotaExhaustion:
         # Events from page 0 are already on the queue and must NOT be retracted
         assert len(publisher.published) == 10
 
-    def test_quota_does_not_raise_to_caller(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_quota_does_not_raise_to_caller(self, sample_query: SearchQuery) -> None:
         """run_search must not propagate QuotaExceededException — it swallows it."""
         service, _, _, _ = _make_service(pages=[[]], fail_on_page=0)
         job = service.run_search(query=sample_query, max_results=50)  # must not raise
@@ -206,9 +190,7 @@ class TestAC06GlobalDeduplication:
     def test_known_video_is_skipped_and_counter_incremented(
         self, sample_query: SearchQuery
     ) -> None:
-        service, _, _, publisher = _make_service(
-            pages=[["vid1", "vid2"]], preexisting={"vid1"}
-        )
+        service, _, _, publisher = _make_service(pages=[["vid1", "vid2"]], preexisting={"vid1"})
         job = service.run_search(query=sample_query, max_results=50)
 
         assert job.duplicates_skipped == 1
@@ -216,23 +198,15 @@ class TestAC06GlobalDeduplication:
         assert not any(e.video_id == "vid1" for e in publisher.published)
         assert any(e.video_id == "vid2" for e in publisher.published)
 
-    def test_known_video_is_not_re_recorded_in_ledger(
-        self, sample_query: SearchQuery
-    ) -> None:
-        service, _, ledger, _ = _make_service(
-            pages=[["vid1"]], preexisting={"vid1"}
-        )
+    def test_known_video_is_not_re_recorded_in_ledger(self, sample_query: SearchQuery) -> None:
+        service, _, ledger, _ = _make_service(pages=[["vid1"]], preexisting={"vid1"})
         service.run_search(query=sample_query, max_results=50)
 
         assert "vid1" not in ledger.recorded  # recorded = NEW writes only
 
-    def test_all_videos_known_yields_zero_discoveries(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_all_videos_known_yields_zero_discoveries(self, sample_query: SearchQuery) -> None:
         all_known = {"vid1", "vid2", "vid3"}
-        service, _, _, publisher = _make_service(
-            pages=[list(all_known)], preexisting=all_known
-        )
+        service, _, _, publisher = _make_service(pages=[list(all_known)], preexisting=all_known)
         job = service.run_search(query=sample_query, max_results=50)
 
         assert job.new_discoveries == 0
@@ -243,9 +217,7 @@ class TestAC06GlobalDeduplication:
         self, sample_query: SearchQuery
     ) -> None:
         """Same videoId appearing on two different pages → emitted only once."""
-        service, _, _, publisher = _make_service(
-            pages=[["vid1", "vid2"], ["vid1", "vid3"]]
-        )
+        service, _, _, publisher = _make_service(pages=[["vid1", "vid2"], ["vid1", "vid3"]])
         job = service.run_search(query=sample_query, max_results=200)
 
         published_ids = [e.video_id for e in publisher.published]
@@ -277,9 +249,7 @@ class TestAC07Pagination:
         assert job.pages_fetched == 3
         assert job.new_discoveries == 30
 
-    def test_ceiling_stops_pagination_before_all_pages(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_ceiling_stops_pagination_before_all_pages(self, sample_query: SearchQuery) -> None:
         """max_results=10, page has 10 videos → loop exits after page 0."""
         pages = [
             [f"vid_p0_{i}" for i in range(10)],  # page 0 → 10 results
@@ -291,13 +261,9 @@ class TestAC07Pagination:
         assert job.pages_fetched == 1
         assert job.new_discoveries == 10
 
-    def test_ceiling_limits_results_on_partial_page(
-        self, sample_query: SearchQuery
-    ) -> None:
+    def test_ceiling_limits_results_on_partial_page(self, sample_query: SearchQuery) -> None:
         """max_results=5 with a page of 10: page_size hint = 5, fake returns 5."""
-        service, youtube, _, publisher = _make_service(
-            pages=[[f"vid{i}" for i in range(10)]]
-        )
+        service, youtube, _, publisher = _make_service(pages=[[f"vid{i}" for i in range(10)]])
         job = service.run_search(query=sample_query, max_results=5)
 
         # First call passes page_size=min(50, 5)=5 → fake returns 5 videos
@@ -326,9 +292,7 @@ class TestAC08SearchFilters:
         assert forwarded_query.filters.language == "pt"
         assert forwarded_query.filters.video_duration == "long"
         assert forwarded_query.filters.region_code == "BR"
-        assert forwarded_query.filters.published_after == datetime(
-            2024, 1, 1, tzinfo=UTC
-        )
+        assert forwarded_query.filters.published_after == datetime(2024, 1, 1, tzinfo=UTC)
 
     def test_no_filters_still_produces_results(self, sample_query: SearchQuery) -> None:
         """Baseline: search without filters works normally."""

--- a/tests/unit/test_video_discovery_service.py
+++ b/tests/unit/test_video_discovery_service.py
@@ -6,10 +6,7 @@ are fast, fully isolated, and require no network access.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Optional
-
-import pytest
+from datetime import UTC, datetime
 
 from mimesis.video_discovery.application.video_discovery_service import (
     VideoDiscoveryService,
@@ -23,14 +20,13 @@ from tests.unit.fakes.fake_discovery_ledger import FakeDiscoveryLedger
 from tests.unit.fakes.fake_event_publisher import FakeEventPublisher
 from tests.unit.fakes.fake_youtube_api import FakeYouTubeApi
 
-
 # ── helpers ──────────────────────────────────────────────────────────────────
 
 
 def _make_service(
     pages: list[list[str]],
-    preexisting: Optional[set[str]] = None,
-    fail_on_page: Optional[int] = None,
+    preexisting: set[str] | None = None,
+    fail_on_page: int | None = None,
 ) -> tuple[VideoDiscoveryService, FakeYouTubeApi, FakeDiscoveryLedger, FakeEventPublisher]:
     youtube = FakeYouTubeApi(pages=pages, fail_on_page=fail_on_page)
     ledger = FakeDiscoveryLedger(preexisting=preexisting or set())
@@ -316,7 +312,7 @@ class TestAC08SearchFilters:
     def test_filters_are_forwarded_to_youtube_api(self) -> None:
         filters = SearchFilters(
             language="pt",
-            published_after=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            published_after=datetime(2024, 1, 1, tzinfo=UTC),
             video_duration="long",
             region_code="BR",
         )
@@ -331,7 +327,7 @@ class TestAC08SearchFilters:
         assert forwarded_query.filters.video_duration == "long"
         assert forwarded_query.filters.region_code == "BR"
         assert forwarded_query.filters.published_after == datetime(
-            2024, 1, 1, tzinfo=timezone.utc
+            2024, 1, 1, tzinfo=UTC
         )
 
     def test_no_filters_still_produces_results(self, sample_query: SearchQuery) -> None:

--- a/tests/unit/test_video_ingestion_service.py
+++ b/tests/unit/test_video_ingestion_service.py
@@ -61,7 +61,9 @@ class FakeLedger(IngestionLedgerPort):
             return self._record
         return None
 
-    def upsert(self, video_id: str, status: IngestionStatus, failure_reason: str | None = None) -> None:
+    def upsert(
+        self, video_id: str, status: IngestionStatus, failure_reason: str | None = None
+    ) -> None:
         self.upserts.append((video_id, status, failure_reason))
         self._record = IngestionRecord(video_id=video_id, status=status)
 
@@ -91,7 +93,6 @@ class FakePublisher(IngestedEventPublisherPort):
 
     def publish(self, event: VideoIngested) -> None:
         self.published.append(event)
-
 
 
 def _sample_payload(video_id: str = "vid123") -> VideoDiscoveredPayload:

--- a/tests/unit/test_video_ingestion_service.py
+++ b/tests/unit/test_video_ingestion_service.py
@@ -1,0 +1,218 @@
+"""Unit tests for BC-02 Video Ingestion service."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from mimesis.video_ingestion.application.video_ingestion_service import (
+    VideoIngestionService,
+    parse_video_discovered_payload,
+)
+from mimesis.video_ingestion.domain.events import VideoIngested
+from mimesis.video_ingestion.domain.exceptions import InvalidVideoDiscoveredEventError
+from mimesis.video_ingestion.domain.models import (
+    ArtifactPaths,
+    IngestionRecord,
+    IngestionStatus,
+    VideoDiscoveredPayload,
+    canonical_paths,
+)
+from mimesis.video_ingestion.ports.artifact_store_port import ArtifactStorePort
+from mimesis.video_ingestion.ports.ingested_event_publisher_port import (
+    IngestedEventPublisherPort,
+)
+from mimesis.video_ingestion.ports.ingestion_ledger_port import IngestionLedgerPort
+from mimesis.video_ingestion.ports.media_processor_port import MediaProcessorPort
+
+
+class FakeArtifactStore(ArtifactStorePort):
+    def __init__(self) -> None:
+        self.uploaded: dict[str, bytes] = {}
+
+    def artifacts_complete(self, paths: ArtifactPaths) -> bool:
+        return all(
+            path in self.uploaded
+            for path in [paths.video_path, paths.audio_path, paths.metadata_path]
+        )
+
+    def upload_video(self, path: str, content: bytes) -> str:
+        self.uploaded[path] = content
+        return f"https://example.blob.core.windows.net/{path}"
+
+    def upload_audio(self, path: str, content: bytes) -> str:
+        self.uploaded[path] = content
+        return f"https://example.blob.core.windows.net/{path}"
+
+    def upload_metadata(self, path: str, content: bytes) -> str:
+        self.uploaded[path] = content
+        return f"https://example.blob.core.windows.net/{path}"
+
+
+class FakeLedger(IngestionLedgerPort):
+    def __init__(self, initial: IngestionRecord | None = None) -> None:
+        self._record = initial
+        self.upserts: list[tuple[str, IngestionStatus, str | None]] = []
+
+    def get(self, video_id: str) -> IngestionRecord | None:
+        if self._record and self._record.video_id == video_id:
+            return self._record
+        return None
+
+    def upsert(self, video_id: str, status: IngestionStatus, failure_reason: str | None = None) -> None:
+        self.upserts.append((video_id, status, failure_reason))
+        self._record = IngestionRecord(video_id=video_id, status=status)
+
+
+class FakeMediaProcessor(MediaProcessorPort):
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.download_calls: list[str] = []
+        self.extract_calls = 0
+
+    def download_source_video(self, youtube_url: str) -> bytes:
+        self.download_calls.append(youtube_url)
+        if self.fail:
+            raise RuntimeError("download failed")
+        return b"video"
+
+    def extract_audio_mp3(self, source_video_bytes: bytes) -> bytes:
+        self.extract_calls += 1
+        if self.fail:
+            raise RuntimeError("extract failed")
+        return b"audio"
+
+
+class FakePublisher(IngestedEventPublisherPort):
+    def __init__(self) -> None:
+        self.published: list[VideoIngested] = []
+
+    def publish(self, event: VideoIngested) -> None:
+        self.published.append(event)
+
+
+
+def _sample_payload(video_id: str = "vid123") -> VideoDiscoveredPayload:
+    return VideoDiscoveredPayload(
+        search_job_id="job-1",
+        video_id=video_id,
+        occurred_at=datetime(2026, 1, 1, tzinfo=UTC),
+        metadata={"title": "Video"},
+    )
+
+
+class TestIngestionService:
+    def test_processes_new_video_and_emits_event(self) -> None:
+        store = FakeArtifactStore()
+        ledger = FakeLedger()
+        media = FakeMediaProcessor()
+        publisher = FakePublisher()
+
+        service = VideoIngestionService(
+            artifact_store=store,
+            ledger=ledger,
+            media_processor=media,
+            event_publisher=publisher,
+        )
+
+        result = service.ingest_discovered_video(_sample_payload())
+
+        assert result.status == IngestionStatus.COMPLETED
+        assert result.artifacts_complete is True
+        assert result.skipped_as_duplicate is False
+        assert len(publisher.published) == 1
+
+        paths = canonical_paths("vid123")
+        assert paths.video_path in store.uploaded
+        assert paths.audio_path in store.uploaded
+        assert paths.metadata_path in store.uploaded
+
+    def test_skips_duplicate_when_completed_and_artifacts_exist(self) -> None:
+        store = FakeArtifactStore()
+        paths = canonical_paths("vid123")
+        store.uploaded[paths.video_path] = b"v"
+        store.uploaded[paths.audio_path] = b"a"
+        store.uploaded[paths.metadata_path] = b"m"
+
+        ledger = FakeLedger(
+            initial=IngestionRecord(video_id="vid123", status=IngestionStatus.COMPLETED)
+        )
+        media = FakeMediaProcessor()
+        publisher = FakePublisher()
+
+        service = VideoIngestionService(
+            artifact_store=store,
+            ledger=ledger,
+            media_processor=media,
+            event_publisher=publisher,
+        )
+
+        result = service.ingest_discovered_video(_sample_payload())
+
+        assert result.skipped_as_duplicate is True
+        assert media.download_calls == []
+        assert publisher.published == []
+
+    def test_reprocesses_when_ledger_completed_but_artifact_missing(self) -> None:
+        store = FakeArtifactStore()
+        paths = canonical_paths("vid123")
+        store.uploaded[paths.video_path] = b"v"
+        store.uploaded[paths.audio_path] = b"a"
+
+        ledger = FakeLedger(
+            initial=IngestionRecord(video_id="vid123", status=IngestionStatus.COMPLETED)
+        )
+        media = FakeMediaProcessor()
+        publisher = FakePublisher()
+
+        service = VideoIngestionService(
+            artifact_store=store,
+            ledger=ledger,
+            media_processor=media,
+            event_publisher=publisher,
+        )
+
+        result = service.ingest_discovered_video(_sample_payload())
+
+        assert result.skipped_as_duplicate is False
+        assert media.download_calls == ["https://www.youtube.com/watch?v=vid123"]
+        assert len(publisher.published) == 1
+
+    def test_marks_failed_on_processing_error(self) -> None:
+        store = FakeArtifactStore()
+        ledger = FakeLedger()
+        media = FakeMediaProcessor(fail=True)
+        publisher = FakePublisher()
+
+        service = VideoIngestionService(
+            artifact_store=store,
+            ledger=ledger,
+            media_processor=media,
+            event_publisher=publisher,
+        )
+
+        with pytest.raises(RuntimeError):
+            service.ingest_discovered_video(_sample_payload())
+
+        assert ledger.upserts[-1][1] == IngestionStatus.FAILED
+
+
+class TestPayloadParsing:
+    def test_parses_valid_payload(self) -> None:
+        raw = json.dumps(
+            {
+                "search_job_id": "job-1",
+                "video_id": "vid123",
+                "occurred_at": "2026-01-01T00:00:00+00:00",
+                "metadata": {"title": "x"},
+            }
+        )
+        parsed = parse_video_discovered_payload(raw)
+        assert parsed.video_id == "vid123"
+
+    def test_rejects_missing_fields(self) -> None:
+        raw = json.dumps({"video_id": "vid123"})
+        with pytest.raises(InvalidVideoDiscoveredEventError):
+            parse_video_discovered_payload(raw)


### PR DESCRIPTION
## Summary
Implements issue #8 for BC-02 Video Ingestion.

### What was added
- New BC-02 package at src/mimesis/video_ingestion:
  - Service Bus trigger function host for sb-queue-video-discovered
  - Application service for ingestion orchestration
  - Idempotency ledger adapter (Azure Table Storage)
  - Blob artifact store adapter (source video, audio, metadata)
  - Media processor adapter (pytubefix + pydub/ffmpeg)
  - VideoIngested v1 event model and Service Bus publisher (sb-queue-video-ingested)
- Terraform updates:
  - Added queue sb-queue-video-ingested
  - Added ingestion ledger table ingestionLedger
  - Added blob containers raw-videos, extracted-audio, video-metadata
  - Added 30-day lifecycle policy for raw video retention
  - Added managed identity role assignment: Storage Blob Data Contributor
  - Added outputs for new queue/table/containers
- Dependencies updated in pyproject.toml:
  - azure-functions, azure-storage-blob, pytubefix, pydub
- Unit tests:
  - Added tests/unit/test_video_ingestion_service.py
- Architecture register updated:
  - BC-02 marked as Designed
  - VideoIngested added to domain event catalog

## Validation
- ruff check src/mimesis/video_ingestion tests/unit/test_video_ingestion_service.py
- mypy src/mimesis/video_ingestion
- pytest tests/unit/test_video_ingestion_service.py -q
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate

Closes #8
