### PR TITLE
fix(terraform): upgrade provider lock file from azurerm 3.x to 4.68.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ infrastructure/terraform/secrets.auto.tfvars
 
 # Terraform — generated / local state (state is remote; backend.hcl is local config)
 infrastructure/terraform/.terraform/
-infrastructure/terraform/.terraform.lock.hcl
+# .terraform.lock.hcl must be committed so CI uses pinned provider versions
 infrastructure/terraform/terraform.tfstate
 infrastructure/terraform/terraform.tfstate.backup
 infrastructure/terraform/crash.log

--- a/infrastructure/terraform/.terraform.lock.hcl
+++ b/infrastructure/terraform/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/azure/azapi" {
+  version     = "2.9.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:tF2SjvM2Vj+7MTbFXhssLYu1Uc9uK/cVWBYIH8heDqM=",
+    "zh:0a4eee8c9362db6ca19d371eccf38701c8306be761182da87b624294f7e8f867",
+    "zh:4df87bee5b8f4cce27461ae26132a599542583cdf035942b42b0259a514ab46e",
+    "zh:57dc1f4227f1d0eab630fcf868d6c9a1b4dc4c165608ce5a4d7028a482770547",
+    "zh:5c500e42c419c324ea8f41c40e4cc8af187323cebc9f70543749b6c0e59c0fe9",
+    "zh:6c7dca31242e27d2f215b1a9370b65579b3a988282a3609564ea96866f86f0ca",
+    "zh:74dada7351b25d01e61aa70aa8cf1f1fb96d09c514be4b66d12816c5e61f9e01",
+    "zh:9c67c0727ab8be15879793f929f3d71f0f149ae1daaf577d0bd4d57b2e61c408",
+    "zh:a0266da16db14b635a61d6766efc28468056bac91ed6662fc9f2a0aad923b063",
+    "zh:a4a555627f40fa797b34ddede599812cddb1e0e9be105ccfcf1f293451b97cd7",
+    "zh:a6a1c4a46f4f01e4420a456adefe8bcf3bff3c9d09a8dfeedeea5b94c866dfd8",
+    "zh:c64fc4067a8276d4405d9359990e0c45e66dba07433a1f3ab1e6c32f6ef3b048",
+    "zh:ee77a881d071b3a0ad8a64f9c1158e3aee9b37e9063de5dd8fa9d238dbe70ba1",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.68.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:nHpvuCg9eexZFeRmH1OCmllvgaLgX0mSApo/uZ6B0Y4=",
+    "zh:08865385ea0c84d208d6ca16644336466e836d56c3639ac369210dbcb9187fb1",
+    "zh:0a42695cb13eefe955ad183e560a8bd35cfb714834525fd5b3749d66d347a562",
+    "zh:195b77405fc54bfc21aa0b20f63f34ad0362fe856cdade7db5a11cd16ae53d4d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:996d0baa2d8462c55631f7c7982b8786ef7f632e3b401ebb596339178b7941a0",
+    "zh:99d43f9edfe225ade0069bd53634c7ae9208297c65db50f26ba5a31c1df3c9c3",
+    "zh:9e7a9d4dee8fd53dba6b0adf5485400f07ee0c603a079000e6246ca69e7ecfd4",
+    "zh:a59ce7d80bc451f03c88afd97cd5effad3079cea4974f0350527abec805e1fd4",
+    "zh:a9a6772178c1e40203c48a56ae611fb09625d1db64357c04ead34b60249188a3",
+    "zh:bdf0f56843cb67174cb32a2956701ac1b68bbdc5c311c62900de72f247d3d42d",
+    "zh:d02a5cd102ef3bfd98373b4d5e711b2f2d403595f4606fc29a897167da36edba",
+    "zh:dbbbb5a9da53e4a71b0b996c3abb9fe3f7422e07f50f5cf2f6eb56fa4ddd66e1",
+  ]
+}


### PR DESCRIPTION
## Root Cause

`terraform init` in CI was failing with exit code 1 before plan even ran (28s total):

```
Error: Failed to query available provider packages

locked provider registry.terraform.io/hashicorp/azurerm 3.117.1 does not match
configured version constraint ~> 4.0; must use terraform init -upgrade
```

The `.terraform.lock.hcl` pinned **azurerm 3.117.1** (constraint `~> 3.100`) while `provider.tf` declares `~> 4.0`. Additionally, the lock file was listed in `.gitignore`, so it was never committed — meaning each CI run started with no lock file and a stale local state from a previous init.

## Fix

1. **`.gitignore`** — removed the incorrect exclusion of `.terraform.lock.hcl`. The lock file must be committed so CI pins consistent provider versions.
2. **`.terraform.lock.hcl`** — ran `terraform init -upgrade`; now pins `azurerm 4.68.0` (satisfies `~> 4.0`) and `azapi 2.9.0`. Validated with `terraform validate` — config is valid.

## Validation

- `terraform validate` passes with warnings only (deprecated `enable_rbac_authorization` → `rbac_authorization_enabled`, not a blocker).
- `terraform init` (without `-upgrade`) now succeeds with the committed lock file.

Closes #22
