### PR TITLE
fix(video-discovery): pass httplib2.Http to build() to avoid Google ADC lookup

### DIFF
--- a/src/mimesis/video_discovery/infra/youtube_api_client.py
+++ b/src/mimesis/video_discovery/infra/youtube_api_client.py
@@ -12,6 +12,7 @@ import logging
 from datetime import datetime
 from typing import Any, cast
 
+import httplib2
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
@@ -73,11 +74,15 @@ class YouTubeApiClient(YouTubeApiPort):
     """Calls YouTube Data API v3 search.list + videos.list per page."""
 
     def __init__(self, api_key: str) -> None:
+        # Pass an explicit http object to prevent google-api-python-client from
+        # calling google.auth.default() — which fails in Azure (no Google ADC).
+        # The developerKey is still appended to every request URL.
         self._service = build(
             _YT_API_SERVICE,
             _YT_API_VERSION,
             developerKey=api_key,
             cache_discovery=False,
+            http=httplib2.Http(),
         )
 
     def search_page(

--- a/tests/unit/test_youtube_api_client.py
+++ b/tests/unit/test_youtube_api_client.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import httplib2
-import pytest
 
 from mimesis.video_discovery.infra.youtube_api_client import YouTubeApiClient
 

--- a/tests/unit/test_youtube_api_client.py
+++ b/tests/unit/test_youtube_api_client.py
@@ -1,0 +1,65 @@
+"""Unit tests for YouTubeApiClient — covers ADC regression (issue #25).
+
+These tests verify that YouTubeApiClient construction does NOT trigger
+google.auth.default() (which fails in Azure where no Google ADC is present).
+The googleapiclient.discovery.build call is patched to avoid network I/O.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httplib2
+import pytest
+
+from mimesis.video_discovery.infra.youtube_api_client import YouTubeApiClient
+
+
+class TestYouTubeApiClientInit:
+    """Regression tests for issue #25 — missing Google ADC in Azure."""
+
+    def test_init_does_not_call_google_auth_default(self) -> None:
+        """Constructing YouTubeApiClient must never invoke google.auth.default().
+
+        If google.auth.default() is called the function will fail in Azure
+        where no Google Application Default Credentials are configured.
+        """
+        with (
+            patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build,
+            patch("google.auth.default") as mock_adc,
+        ):
+            mock_build.return_value = MagicMock()
+
+            YouTubeApiClient(api_key="fake-api-key")
+
+            mock_adc.assert_not_called()
+
+    def test_init_passes_httplib2_http_to_build(self) -> None:
+        """build() must receive an httplib2.Http instance to bypass ADC lookup."""
+        with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
+            mock_build.return_value = MagicMock()
+
+            YouTubeApiClient(api_key="fake-api-key")
+
+            _, kwargs = mock_build.call_args
+            assert isinstance(kwargs.get("http"), httplib2.Http)
+
+    def test_init_passes_developer_key_to_build(self) -> None:
+        """build() must receive the API key as developerKey."""
+        with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
+            mock_build.return_value = MagicMock()
+
+            YouTubeApiClient(api_key="my-secret-key")
+
+            _, kwargs = mock_build.call_args
+            assert kwargs.get("developerKey") == "my-secret-key"
+
+    def test_init_disables_discovery_cache(self) -> None:
+        """build() must be called with cache_discovery=False."""
+        with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
+            mock_build.return_value = MagicMock()
+
+            YouTubeApiClient(api_key="fake-api-key")
+
+            _, kwargs = mock_build.call_args
+            assert kwargs.get("cache_discovery") is False


### PR DESCRIPTION
## Summary

Fixes #25

## Root cause

`google-api-python-client`'s `build()` calls `google.auth.default()` during construction even when only a `developerKey` is supplied. The Azure Function environment has no Google Application Default Credentials, so this raises `DefaultCredentialsError` before any YouTube API call is made.

## Fix

Pass an explicit `http=httplib2.Http()` instance to `build()`. This gives the client a plain unauthenticated HTTP transport, bypassing the ADC lookup entirely. The `developerKey` continues to be appended to every request URL by the library.

**Changed file:** `src/mimesis/video_discovery/infra/youtube_api_client.py`

## Tests

Added `tests/unit/test_youtube_api_client.py` with 4 regression tests:
- `google.auth.default()` is never called during construction
- `httplib2.Http` is passed to `build()`
- `developerKey` is forwarded correctly
- `cache_discovery=False` is preserved

All 59 unit tests pass.