### PR TITLE
fix(video-discovery): replace googleapiclient with stdlib urllib to eliminate ADC dependency

### DIFF
--- a/.github/workflows/dev-rollout.yml
+++ b/.github/workflows/dev-rollout.yml
@@ -156,12 +156,17 @@ jobs:
             --overwrite \
             --auth-mode login
 
-      # Restart BC-01 so the Flex Consumption runtime picks up the new blob.
-      - name: Restart BC-01 (Video Discovery)
+      # Force Flex Consumption to re-download the deployment blob.
+      # A simple restart reuses the cached extraction; updating an app
+      # setting forces a full cold start that re-reads from blob storage.
+      - name: Force redeploy BC-01 (Video Discovery)
         run: |
-          az functionapp restart \
+          STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+          az functionapp config appsettings set \
             --name "${{ env.AZURE_BC01_FUNCTION_APP_NAME }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}"
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --settings "DEPLOYMENT_STAMP=$STAMP" \
+            --output none
 
       # BC-02: Video Ingestion
       # Packages functions/video-ingestion/ (includes host.json) with all deps.
@@ -188,12 +193,15 @@ jobs:
             --overwrite \
             --auth-mode login
 
-      # Restart BC-02 so the Flex Consumption runtime picks up the new blob.
-      - name: Restart BC-02 (Video Ingestion)
+      # Force Flex Consumption to re-download the deployment blob.
+      - name: Force redeploy BC-02 (Video Ingestion)
         run: |
-          az functionapp restart \
+          STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+          az functionapp config appsettings set \
             --name "${{ env.AZURE_BC02_FUNCTION_APP_NAME }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}"
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --settings "DEPLOYMENT_STAMP=$STAMP" \
+            --output none
 
   # ── 3. Smoke test: verify BC-01 HTTP endpoint and BC-02 function app ────────
   smoke-dev:

--- a/.github/workflows/dev-rollout.yml
+++ b/.github/workflows/dev-rollout.yml
@@ -156,6 +156,13 @@ jobs:
             --overwrite \
             --auth-mode login
 
+      # Restart BC-01 so the Flex Consumption runtime picks up the new blob.
+      - name: Restart BC-01 (Video Discovery)
+        run: |
+          az functionapp restart \
+            --name "${{ env.AZURE_BC01_FUNCTION_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}"
+
       # BC-02: Video Ingestion
       # Packages functions/video-ingestion/ (includes host.json) with all deps.
       - name: Package BC-02 (Video Ingestion)
@@ -180,6 +187,13 @@ jobs:
             --file deploy-bc02.zip \
             --overwrite \
             --auth-mode login
+
+      # Restart BC-02 so the Flex Consumption runtime picks up the new blob.
+      - name: Restart BC-02 (Video Ingestion)
+        run: |
+          az functionapp restart \
+            --name "${{ env.AZURE_BC02_FUNCTION_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}"
 
   # ── 3. Smoke test: verify BC-01 HTTP endpoint and BC-02 function app ────────
   smoke-dev:

--- a/.github/workflows/dev-rollout.yml
+++ b/.github/workflows/dev-rollout.yml
@@ -140,23 +140,91 @@ jobs:
             --exclude "*.pyc" \
             --exclude "*/__pycache__/*"
 
-      # BC-01: Deploy via Kudu zipdeploy (the only method Flex Consumption
-      # recognises for updating the active deployment).
-      # The Flex Consumption SCM endpoint cold-starts and may return 502 on
-      # the first request — retry up to 5 times with 30 s back-off.
+      # BC-01: Deploy by direct blob upload — bypasses the SCM/Kudu endpoint
+      # entirely (which returns 502 on Flex Consumption apps).
+      #
+      # How Flex Consumption resolves its deployment package at cold-start:
+      #   1. Reads kudu-state.json from the deployment blob container.
+      #   2. Looks up ActiveDeploymentId → ResultPackagePath.
+      #   3. If ResultPackagePath is null → falls back to released-package.zip
+      #      in the same container.
+      #
+      # Strategy: upload the pre-built zip as released-package.zip, then write
+      # a fresh kudu-state.json with a new UUID and ResultPackagePath: null.
+      # On the next cold-start the runtime finds no local artifact and loads
+      # from the blob automatically.
       - name: Deploy BC-01 (Video Discovery)
+        env:
+          RG: ${{ env.RESOURCE_GROUP }}
+          APP: ${{ env.AZURE_BC01_FUNCTION_APP_NAME }}
+          SUB: ${{ env.AZURE_SUBSCRIPTION_ID }}
         run: |
-          for attempt in 1 2 3 4 5; do
-            echo "Deploy attempt $attempt/5…"
-            az functionapp deploy \
-              --name "${{ env.AZURE_BC01_FUNCTION_APP_NAME }}" \
-              --resource-group "${{ env.RESOURCE_GROUP }}" \
-              --src-path deploy-bc01.zip \
-              --type zip \
-              --clean true \
-              --restart true && break
-            [ "$attempt" -lt 5 ] && echo "Retrying in 30 s…" && sleep 30 || exit 1
-          done
+          # Derive storage account name from resource group (mimesis-dev-rg → mimesisdevsa)
+          STORAGE_ACCOUNT=$(echo "$RG" | sed 's/-rg$//' | tr -d '-')sa
+          CONTAINER="fn-fd-deploy"
+
+          echo "Storage account : $STORAGE_ACCOUNT"
+          echo "Deployment container: $CONTAINER"
+
+          # 1. Upload new package as released-package.zip
+          az storage blob upload \
+            --account-name "$STORAGE_ACCOUNT" \
+            --container-name "$CONTAINER" \
+            --name released-package.zip \
+            --file deploy-bc01.zip \
+            --overwrite \
+            --auth-mode key
+
+          # 2. Generate fresh kudu-state.json with a new deployment ID
+          DEPLOY_ID=$(python3 -c "import uuid; print(str(uuid.uuid4()))")
+          NOW=$(python3 -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f0Z'))")
+          python3 -c "
+          import json, sys
+          data = {
+              'ActiveDeploymentId': sys.argv[1],
+              'LatestDeploymentId': sys.argv[1],
+              'Deployments': {
+                  sys.argv[1]: {
+                      'Id': sys.argv[1],
+                      'StartTime': sys.argv[2],
+                      'LastModifiedTime': sys.argv[2],
+                      'LastSuccessEndTime': sys.argv[2],
+                      'EndTime': sys.argv[2],
+                      'CreatedBy': None,
+                      'Deployer': 'az_cli',
+                      'RemoteBuild': False,
+                      'SourcePackageUri': None,
+                      'SourcePackagePath': None,
+                      'ResultPackagePath': None,
+                      'Complete': True,
+                      'Status': 4,
+                      'StatusText': '',
+                      'UploadedPackageName': 'released-package.zip',
+                      'KuduRestartCount': 0,
+                      'LatestDeploymentStep': 'Kudu-SyncTriggerStep',
+                      'FDMEnabled': False,
+                      'FDMPingRecorded': False
+                  }
+              }
+          }
+          print(json.dumps(data))
+          " "$DEPLOY_ID" "$NOW" > /tmp/kudu-state-bc01.json
+
+          # 3. Upload new kudu-state.json
+          az storage blob upload \
+            --account-name "$STORAGE_ACCOUNT" \
+            --container-name "$CONTAINER" \
+            --name kudu-state.json \
+            --file /tmp/kudu-state-bc01.json \
+            --overwrite \
+            --auth-mode key
+
+          # 4. Restart (terminates existing workers; next cold-start uses new blob)
+          az functionapp restart --name "$APP" --resource-group "$RG"
+
+          # 5. Notify the platform of updated triggers
+          az rest --method post \
+            --url "https://management.azure.com/subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.Web/sites/$APP/syncfunctiontriggers?api-version=2024-04-01"
 
       # BC-02: Video Ingestion
       # Packages functions/video-ingestion/ (includes host.json) with all deps.
@@ -170,20 +238,73 @@ jobs:
             --exclude "*.pyc" \
             --exclude "*/__pycache__/*"
 
-      # BC-02: Deploy via Kudu zipdeploy (with retry for cold-start 502).
+      # BC-02: Deploy by direct blob upload (same strategy as BC-01 above).
       - name: Deploy BC-02 (Video Ingestion)
+        env:
+          RG: ${{ env.RESOURCE_GROUP }}
+          APP: ${{ env.AZURE_BC02_FUNCTION_APP_NAME }}
+          SUB: ${{ env.AZURE_SUBSCRIPTION_ID }}
         run: |
-          for attempt in 1 2 3 4 5; do
-            echo "Deploy attempt $attempt/5…"
-            az functionapp deploy \
-              --name "${{ env.AZURE_BC02_FUNCTION_APP_NAME }}" \
-              --resource-group "${{ env.RESOURCE_GROUP }}" \
-              --src-path deploy-bc02.zip \
-              --type zip \
-              --clean true \
-              --restart true && break
-            [ "$attempt" -lt 5 ] && echo "Retrying in 30 s…" && sleep 30 || exit 1
-          done
+          STORAGE_ACCOUNT=$(echo "$RG" | sed 's/-rg$//' | tr -d '-')sa
+          CONTAINER="fn-fi-deploy"
+
+          echo "Storage account : $STORAGE_ACCOUNT"
+          echo "Deployment container: $CONTAINER"
+
+          az storage blob upload \
+            --account-name "$STORAGE_ACCOUNT" \
+            --container-name "$CONTAINER" \
+            --name released-package.zip \
+            --file deploy-bc02.zip \
+            --overwrite \
+            --auth-mode key
+
+          DEPLOY_ID=$(python3 -c "import uuid; print(str(uuid.uuid4()))")
+          NOW=$(python3 -c "from datetime import datetime, timezone; print(datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f0Z'))")
+          python3 -c "
+          import json, sys
+          data = {
+              'ActiveDeploymentId': sys.argv[1],
+              'LatestDeploymentId': sys.argv[1],
+              'Deployments': {
+                  sys.argv[1]: {
+                      'Id': sys.argv[1],
+                      'StartTime': sys.argv[2],
+                      'LastModifiedTime': sys.argv[2],
+                      'LastSuccessEndTime': sys.argv[2],
+                      'EndTime': sys.argv[2],
+                      'CreatedBy': None,
+                      'Deployer': 'az_cli',
+                      'RemoteBuild': False,
+                      'SourcePackageUri': None,
+                      'SourcePackagePath': None,
+                      'ResultPackagePath': None,
+                      'Complete': True,
+                      'Status': 4,
+                      'StatusText': '',
+                      'UploadedPackageName': 'released-package.zip',
+                      'KuduRestartCount': 0,
+                      'LatestDeploymentStep': 'Kudu-SyncTriggerStep',
+                      'FDMEnabled': False,
+                      'FDMPingRecorded': False
+                  }
+              }
+          }
+          print(json.dumps(data))
+          " "$DEPLOY_ID" "$NOW" > /tmp/kudu-state-bc02.json
+
+          az storage blob upload \
+            --account-name "$STORAGE_ACCOUNT" \
+            --container-name "$CONTAINER" \
+            --name kudu-state.json \
+            --file /tmp/kudu-state-bc02.json \
+            --overwrite \
+            --auth-mode key
+
+          az functionapp restart --name "$APP" --resource-group "$RG"
+
+          az rest --method post \
+            --url "https://management.azure.com/subscriptions/$SUB/resourceGroups/$RG/providers/Microsoft.Web/sites/$APP/syncfunctiontriggers?api-version=2024-04-01"
 
   # ── 3. Smoke test: verify BC-01 HTTP endpoint and BC-02 function app ────────
   smoke-dev:

--- a/.github/workflows/dev-rollout.yml
+++ b/.github/workflows/dev-rollout.yml
@@ -90,7 +90,6 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       AZURE_BC01_FUNCTION_APP_NAME: ${{ secrets.AZURE_BC01_FUNCTION_APP_NAME }}
       AZURE_BC02_FUNCTION_APP_NAME: ${{ secrets.AZURE_BC02_FUNCTION_APP_NAME }}
-      AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
 
     steps:
       - uses: actions/checkout@v4
@@ -98,7 +97,7 @@ jobs:
       - name: Preflight required deploy inputs
         run: |
           missing=0
-          for var in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_BC01_FUNCTION_APP_NAME AZURE_BC02_FUNCTION_APP_NAME AZURE_STORAGE_ACCOUNT; do
+          for var in AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID AZURE_BC01_FUNCTION_APP_NAME AZURE_BC02_FUNCTION_APP_NAME; do
             if [ -z "${!var}" ]; then
               echo "Missing required value: $var (set as repository secret or variable)"
               missing=1
@@ -141,32 +140,19 @@ jobs:
             --exclude "*.pyc" \
             --exclude "*/__pycache__/*"
 
-      # BC-01: Upload zip to its FC1 deployment blob container.
-      # FC1 (Flex Consumption) does not use Kudu zipdeploy; the runtime reads
-      # the package from the blob container configured in functionAppConfig.
+      # BC-01: Deploy via Kudu zipdeploy (the only method Flex Consumption
+      # recognises for updating the active deployment).
+      # Raw blob upload to the container is NOT sufficient — Kudu tracks the
+      # active deployment in kudu-state.json and serves from released-package.zip.
       - name: Deploy BC-01 (Video Discovery)
-        env:
-          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
         run: |
-          az storage blob upload \
-            --account-name "$AZURE_STORAGE_ACCOUNT" \
-            --container-name fn-fd-deploy \
-            --name run-from-package.zip \
-            --file deploy-bc01.zip \
-            --overwrite \
-            --auth-mode login
-
-      # Force Flex Consumption to re-download the deployment blob.
-      # A simple restart reuses the cached extraction; updating an app
-      # setting forces a full cold start that re-reads from blob storage.
-      - name: Force redeploy BC-01 (Video Discovery)
-        run: |
-          STAMP=$(date -u +%Y%m%dT%H%M%SZ)
-          az functionapp config appsettings set \
+          az functionapp deploy \
             --name "${{ env.AZURE_BC01_FUNCTION_APP_NAME }}" \
             --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --settings "DEPLOYMENT_STAMP=$STAMP" \
-            --output none
+            --src-path deploy-bc01.zip \
+            --type zip \
+            --clean true \
+            --restart true
 
       # BC-02: Video Ingestion
       # Packages functions/video-ingestion/ (includes host.json) with all deps.
@@ -180,28 +166,16 @@ jobs:
             --exclude "*.pyc" \
             --exclude "*/__pycache__/*"
 
-      # BC-02: Upload zip to its FC1 deployment blob container.
+      # BC-02: Deploy via Kudu zipdeploy.
       - name: Deploy BC-02 (Video Ingestion)
-        env:
-          AZURE_STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT }}
         run: |
-          az storage blob upload \
-            --account-name "$AZURE_STORAGE_ACCOUNT" \
-            --container-name fn-fi-deploy \
-            --name run-from-package.zip \
-            --file deploy-bc02.zip \
-            --overwrite \
-            --auth-mode login
-
-      # Force Flex Consumption to re-download the deployment blob.
-      - name: Force redeploy BC-02 (Video Ingestion)
-        run: |
-          STAMP=$(date -u +%Y%m%dT%H%M%SZ)
-          az functionapp config appsettings set \
+          az functionapp deploy \
             --name "${{ env.AZURE_BC02_FUNCTION_APP_NAME }}" \
             --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --settings "DEPLOYMENT_STAMP=$STAMP" \
-            --output none
+            --src-path deploy-bc02.zip \
+            --type zip \
+            --clean true \
+            --restart true
 
   # ── 3. Smoke test: verify BC-01 HTTP endpoint and BC-02 function app ────────
   smoke-dev:

--- a/.github/workflows/dev-rollout.yml
+++ b/.github/workflows/dev-rollout.yml
@@ -142,17 +142,21 @@ jobs:
 
       # BC-01: Deploy via Kudu zipdeploy (the only method Flex Consumption
       # recognises for updating the active deployment).
-      # Raw blob upload to the container is NOT sufficient — Kudu tracks the
-      # active deployment in kudu-state.json and serves from released-package.zip.
+      # The Flex Consumption SCM endpoint cold-starts and may return 502 on
+      # the first request — retry up to 5 times with 30 s back-off.
       - name: Deploy BC-01 (Video Discovery)
         run: |
-          az functionapp deploy \
-            --name "${{ env.AZURE_BC01_FUNCTION_APP_NAME }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --src-path deploy-bc01.zip \
-            --type zip \
-            --clean true \
-            --restart true
+          for attempt in 1 2 3 4 5; do
+            echo "Deploy attempt $attempt/5…"
+            az functionapp deploy \
+              --name "${{ env.AZURE_BC01_FUNCTION_APP_NAME }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --src-path deploy-bc01.zip \
+              --type zip \
+              --clean true \
+              --restart true && break
+            [ "$attempt" -lt 5 ] && echo "Retrying in 30 s…" && sleep 30 || exit 1
+          done
 
       # BC-02: Video Ingestion
       # Packages functions/video-ingestion/ (includes host.json) with all deps.
@@ -166,16 +170,20 @@ jobs:
             --exclude "*.pyc" \
             --exclude "*/__pycache__/*"
 
-      # BC-02: Deploy via Kudu zipdeploy.
+      # BC-02: Deploy via Kudu zipdeploy (with retry for cold-start 502).
       - name: Deploy BC-02 (Video Ingestion)
         run: |
-          az functionapp deploy \
-            --name "${{ env.AZURE_BC02_FUNCTION_APP_NAME }}" \
-            --resource-group "${{ env.RESOURCE_GROUP }}" \
-            --src-path deploy-bc02.zip \
-            --type zip \
-            --clean true \
-            --restart true
+          for attempt in 1 2 3 4 5; do
+            echo "Deploy attempt $attempt/5…"
+            az functionapp deploy \
+              --name "${{ env.AZURE_BC02_FUNCTION_APP_NAME }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --src-path deploy-bc02.zip \
+              --type zip \
+              --clean true \
+              --restart true && break
+            [ "$attempt" -lt 5 ] && echo "Retrying in 30 s…" && sleep 30 || exit 1
+          done
 
   # ── 3. Smoke test: verify BC-01 HTTP endpoint and BC-02 function app ────────
   smoke-dev:

--- a/src/mimesis/video_discovery/application/video_discovery_service.py
+++ b/src/mimesis/video_discovery/application/video_discovery_service.py
@@ -62,14 +62,15 @@ class VideoDiscoveryService:
 
         try:
             self._paginate_and_emit(job, query, max_results)
-        except QuotaExceededException:
+        except QuotaExceededException as exc:
             logger.error(
                 "YouTube quota exhausted — SearchJob failed | job_id=%s "
-                "new_discoveries=%d duplicates_skipped=%d pages_fetched=%d",
+                "new_discoveries=%d duplicates_skipped=%d pages_fetched=%d error=%s",
                 job.search_job_id,
                 job.new_discoveries,
                 job.duplicates_skipped,
                 job.pages_fetched,
+                exc,
             )
             job.mark_failed()
             return job

--- a/src/mimesis/video_discovery/infra/youtube_api_client.py
+++ b/src/mimesis/video_discovery/infra/youtube_api_client.py
@@ -104,6 +104,7 @@ class YouTubeApiClient(YouTubeApiPort):
     """
 
     def __init__(self, api_key: str) -> None:
+        logger.info("Running the updated version — urllib-based YouTubeApiClient (issues #25, #27)")
         self._api_key = api_key
 
     def search_page(

--- a/src/mimesis/video_discovery/infra/youtube_api_client.py
+++ b/src/mimesis/video_discovery/infra/youtube_api_client.py
@@ -89,7 +89,19 @@ def _yt_get(url: str) -> dict[str, Any]:
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")
         if exc.code == 403:
-            raise QuotaExceededException(f"HTTP 403: {body}") from exc
+            # Parse the Google API error body to distinguish quota exhaustion
+            # from other 403 causes (IP restriction, key restriction, etc.).
+            reason: str = "unknown"
+            try:
+                error_json = json.loads(body)
+                errors = error_json.get("error", {}).get("errors", [])
+                reason = str(errors[0].get("reason", "unknown")) if errors else "unknown"
+            except (json.JSONDecodeError, IndexError, KeyError):
+                pass
+            logger.error("YouTube API 403 | reason=%s body=%s", reason, body)
+            if reason in {"quotaExceeded", "dailyLimitExceeded"}:
+                raise QuotaExceededException(f"HTTP 403 ({reason}): {body}") from exc
+            raise YouTubeApiError(f"HTTP 403 ({reason}): {body}") from exc
         raise YouTubeApiError(f"HTTP {exc.code}: {body}") from exc
     except urllib.error.URLError as exc:
         raise YouTubeApiError(f"URL error: {exc.reason}") from exc
@@ -104,7 +116,10 @@ class YouTubeApiClient(YouTubeApiPort):
     """
 
     def __init__(self, api_key: str) -> None:
-        logger.info("Running the updated version — urllib-based YouTubeApiClient (issues #25, #27)")
+        logger.info(
+            "Running the updated version — urllib-based YouTubeApiClient (issues #25, #27) | key=...%s",
+            api_key[-4:],
+        )
         self._api_key = api_key
 
     def search_page(

--- a/src/mimesis/video_discovery/infra/youtube_api_client.py
+++ b/src/mimesis/video_discovery/infra/youtube_api_client.py
@@ -1,6 +1,10 @@
 """YouTube Data API v3 adapter — concrete implementation of YouTubeApiPort.
 
-Uses ``google-api-python-client`` with a developer key retrieved from Key Vault.
+Direct REST implementation using stdlib urllib. Does NOT use
+google-api-python-client, which unconditionally invokes google.auth.default()
+in some versions — a call that always fails inside Azure Functions where no
+Google Application Default Credentials are present (issues #25, #27).
+
 Two-call strategy per page (ADR-03):
   1. ``search.list``  → videoIds
   2. ``videos.list``  → full metadata batch (1 quota unit)
@@ -8,13 +12,13 @@ Two-call strategy per page (ADR-03):
 
 from __future__ import annotations
 
+import json
 import logging
+import urllib.error
+import urllib.parse
+import urllib.request
 from datetime import datetime
 from typing import Any, cast
-
-from google.auth.credentials import AnonymousCredentials
-from googleapiclient.discovery import build
-from googleapiclient.errors import HttpError
 
 from mimesis.video_discovery.domain.exceptions import (
     QuotaExceededException,
@@ -25,8 +29,7 @@ from mimesis.video_discovery.ports.youtube_api_port import SearchPage, YouTubeAp
 
 logger = logging.getLogger(__name__)
 
-_YT_API_SERVICE = "youtube"
-_YT_API_VERSION = "v3"
+_YT_API_BASE = "https://www.googleapis.com/youtube/v3"
 
 
 def _safe_int(value: object) -> int | None:
@@ -70,22 +73,38 @@ def _parse_metadata(item: dict[str, Any]) -> tuple[str, VideoMetadata]:
     return video_id, metadata
 
 
+def _yt_get(url: str) -> dict[str, Any]:
+    """Issue an unauthenticated GET to the YouTube Data API and return parsed JSON.
+
+    The API key is embedded in the URL query string by the caller; no
+    Authorization header is needed for developer-key access.
+
+    Raises:
+        QuotaExceededException: on HTTP 403 (quota exceeded).
+        YouTubeApiError: on any other HTTP or network error.
+    """
+    try:
+        with urllib.request.urlopen(url) as response:  # noqa: S310
+            return cast(dict[str, Any], json.loads(response.read().decode()))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        if exc.code == 403:
+            raise QuotaExceededException(f"HTTP 403: {body}") from exc
+        raise YouTubeApiError(f"HTTP {exc.code}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise YouTubeApiError(f"URL error: {exc.reason}") from exc
+
+
 class YouTubeApiClient(YouTubeApiPort):
-    """Calls YouTube Data API v3 search.list + videos.list per page."""
+    """Calls YouTube Data API v3 search.list + videos.list per page.
+
+    Uses plain urllib (stdlib) so that no Google authentication library is
+    involved at all — avoiding google.auth.default() which fails in Azure
+    where there are no Google Application Default Credentials.
+    """
 
     def __init__(self, api_key: str) -> None:
-        # Explicitly pass AnonymousCredentials to prevent google-api-python-client
-        # from calling google.auth.default() inside build_from_document(), which
-        # fails in Azure where no Google Application Default Credentials exist.
-        # AnonymousCredentials adds no Authorization header; the developerKey is
-        # appended as a URL query parameter by the client library on every request.
-        self._service = build(
-            _YT_API_SERVICE,
-            _YT_API_VERSION,
-            developerKey=api_key,
-            cache_discovery=False,
-            credentials=AnonymousCredentials(),  # type: ignore[no-untyped-call]
-        )
+        self._api_key = api_key
 
     def search_page(
         self,
@@ -96,34 +115,29 @@ class YouTubeApiClient(YouTubeApiPort):
         filters = query.filters
 
         # ── 1. search.list ───────────────────────────────────────────────────
-        search_kwargs: dict[str, object] = {
+        search_params: dict[str, str] = {
             "q": query.keyword,
             "part": "snippet",
             "type": "video",
-            "maxResults": min(page_size, 50),
+            "maxResults": str(min(page_size, 50)),
+            "key": self._api_key,
         }
         if page_token:
-            search_kwargs["pageToken"] = page_token
+            search_params["pageToken"] = page_token
         if filters:
             if filters.language:
-                search_kwargs["relevanceLanguage"] = filters.language
+                search_params["relevanceLanguage"] = filters.language
             if filters.published_after:
-                search_kwargs["publishedAfter"] = filters.published_after.strftime(
+                search_params["publishedAfter"] = filters.published_after.strftime(
                     "%Y-%m-%dT%H:%M:%SZ"
                 )
             if filters.video_duration:
-                search_kwargs["videoDuration"] = filters.video_duration
+                search_params["videoDuration"] = filters.video_duration
             if filters.region_code:
-                search_kwargs["regionCode"] = filters.region_code
+                search_params["regionCode"] = filters.region_code
 
-        try:
-            search_response: dict[str, object] = (
-                self._service.search().list(**search_kwargs).execute()
-            )
-        except HttpError as exc:
-            if exc.resp.status == 403:
-                raise QuotaExceededException(str(exc)) from exc
-            raise YouTubeApiError(str(exc)) from exc
+        search_url = f"{_YT_API_BASE}/search?{urllib.parse.urlencode(search_params)}"
+        search_response = _yt_get(search_url)
 
         items = cast(list[dict[str, Any]], search_response.get("items", []))
         next_page_token_raw = search_response.get("nextPageToken")
@@ -134,17 +148,13 @@ class YouTubeApiClient(YouTubeApiPort):
 
         # ── 2. videos.list (batch) ───────────────────────────────────────────
         video_ids = ",".join(str(item["id"]["videoId"]) for item in items)
-
-        try:
-            videos_response: dict[str, object] = (
-                self._service.videos()
-                .list(id=video_ids, part="snippet,contentDetails,statistics")
-                .execute()
-            )
-        except HttpError as exc:
-            if exc.resp.status == 403:
-                raise QuotaExceededException(str(exc)) from exc
-            raise YouTubeApiError(str(exc)) from exc
+        videos_params: dict[str, str] = {
+            "id": video_ids,
+            "part": "snippet,contentDetails,statistics",
+            "key": self._api_key,
+        }
+        videos_url = f"{_YT_API_BASE}/videos?{urllib.parse.urlencode(videos_params)}"
+        videos_response = _yt_get(videos_url)
 
         video_items = cast(list[dict[str, Any]], videos_response.get("items", []))
         results = [_parse_metadata(item) for item in video_items]
@@ -155,4 +165,5 @@ class YouTubeApiClient(YouTubeApiPort):
             page_token,
             len(results),
         )
+
         return SearchPage(video_metadatas=results, next_page_token=next_page_token)

--- a/src/mimesis/video_discovery/infra/youtube_api_client.py
+++ b/src/mimesis/video_discovery/infra/youtube_api_client.py
@@ -12,7 +12,7 @@ import logging
 from datetime import datetime
 from typing import Any, cast
 
-import httplib2
+from google.auth.credentials import AnonymousCredentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
@@ -74,15 +74,17 @@ class YouTubeApiClient(YouTubeApiPort):
     """Calls YouTube Data API v3 search.list + videos.list per page."""
 
     def __init__(self, api_key: str) -> None:
-        # Pass an explicit http object to prevent google-api-python-client from
-        # calling google.auth.default() — which fails in Azure (no Google ADC).
-        # The developerKey is still appended to every request URL.
+        # Explicitly pass AnonymousCredentials to prevent google-api-python-client
+        # from calling google.auth.default() inside build_from_document(), which
+        # fails in Azure where no Google Application Default Credentials exist.
+        # AnonymousCredentials adds no Authorization header; the developerKey is
+        # appended as a URL query parameter by the client library on every request.
         self._service = build(
             _YT_API_SERVICE,
             _YT_API_VERSION,
             developerKey=api_key,
             cache_discovery=False,
-            http=httplib2.Http(),
+            credentials=AnonymousCredentials(),  # type: ignore[no-untyped-call]
         )
 
     def search_page(

--- a/tests/unit/test_youtube_api_client.py
+++ b/tests/unit/test_youtube_api_client.py
@@ -85,8 +85,11 @@ class TestYtGet:
         assert result == payload
 
     def test_raises_quota_exceeded_on_403(self) -> None:
+        _quota_body = json.dumps(
+            {"error": {"errors": [{"reason": "quotaExceeded"}]}}
+        )
         with (
-            patch("urllib.request.urlopen", side_effect=_make_http_error(403, "quota")),
+            patch("urllib.request.urlopen", side_effect=_make_http_error(403, _quota_body)),
             pytest.raises(QuotaExceededException, match="HTTP 403"),
         ):
             _yt_get("https://example.com")
@@ -208,7 +211,8 @@ class TestYouTubeApiClientSearchPage:
 
     def test_propagates_quota_exceeded_exception(self, mocker) -> None:
         client = YouTubeApiClient(api_key="key")
-        mocker.patch("urllib.request.urlopen", side_effect=_make_http_error(403, "quota exceeded"))
+        _quota_body = json.dumps({"error": {"errors": [{"reason": "quotaExceeded"}]}})
+        mocker.patch("urllib.request.urlopen", side_effect=_make_http_error(403, _quota_body))
         from mimesis.video_discovery.domain.models import SearchQuery
 
         with pytest.raises(QuotaExceededException):

--- a/tests/unit/test_youtube_api_client.py
+++ b/tests/unit/test_youtube_api_client.py
@@ -85,9 +85,7 @@ class TestYtGet:
         assert result == payload
 
     def test_raises_quota_exceeded_on_403(self) -> None:
-        _quota_body = json.dumps(
-            {"error": {"errors": [{"reason": "quotaExceeded"}]}}
-        )
+        _quota_body = json.dumps({"error": {"errors": [{"reason": "quotaExceeded"}]}})
         with (
             patch("urllib.request.urlopen", side_effect=_make_http_error(403, _quota_body)),
             pytest.raises(QuotaExceededException, match="HTTP 403"),

--- a/tests/unit/test_youtube_api_client.py
+++ b/tests/unit/test_youtube_api_client.py
@@ -1,85 +1,215 @@
 """Unit tests for YouTubeApiClient — covers ADC regression (issues #25, #27).
 
-These tests verify that YouTubeApiClient construction does NOT trigger
-google.auth.default() (which fails in Azure where no Google ADC is present).
+Root cause: google-api-python-client unconditionally calls google.auth.default()
+in build_from_document() in some deployed versions — even when a developerKey
+or credentials are explicitly provided.  The fix (issue #27) replaces the
+google-api-python-client dependency entirely with direct urllib REST calls,
+eliminating all Google auth machinery from the code path.
 
-Root cause (issue #27): passing http=httplib2.Http() to build() is insufficient
-because google-api-python-client calls _auth.default_credentials() inside
-build_from_document() regardless of whether http is provided. The correct fix
-is to pass credentials=AnonymousCredentials(), which prevents the ADC lookup.
-
-The googleapiclient.discovery.build call is patched to avoid network I/O.
+These tests verify the new implementation without touching the network.
 """
 
 from __future__ import annotations
 
+import json
+import urllib.error
+import urllib.request
+from io import BytesIO
 from unittest.mock import MagicMock, patch
 
-from google.auth.credentials import AnonymousCredentials
+import pytest
 
-from mimesis.video_discovery.infra.youtube_api_client import YouTubeApiClient
+from mimesis.video_discovery.domain.exceptions import (
+    QuotaExceededException,
+    YouTubeApiError,
+)
+from mimesis.video_discovery.infra.youtube_api_client import (
+    YouTubeApiClient,
+    _yt_get,
+)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _make_urlopen_response(data: dict) -> MagicMock:
+    """Return a context-manager-compatible mock for urllib.request.urlopen."""
+    body = json.dumps(data).encode()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _make_http_error(code: int, body: str = "") -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://example.com",
+        code=code,
+        msg=f"HTTP {code}",
+        hdrs=MagicMock(),  # type: ignore[arg-type]
+        fp=BytesIO(body.encode()),
+    )
+
+
+# ── YouTubeApiClient init ─────────────────────────────────────────────────────
 
 
 class TestYouTubeApiClientInit:
-    """Regression tests for issues #25 and #27 — missing Google ADC in Azure."""
+    """Regression: ADC must never be called — issues #25 and #27."""
 
     def test_init_does_not_call_google_auth_default(self) -> None:
-        """Constructing YouTubeApiClient must never invoke google.auth.default().
-
-        If google.auth.default() is called the function will fail in Azure
-        where no Google Application Default Credentials are configured.
-        """
-        with (
-            patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build,
-            patch("google.auth.default") as mock_adc,
-        ):
-            mock_build.return_value = MagicMock()
-
-            YouTubeApiClient(api_key="fake-api-key")
-
+        """Construction must not trigger google.auth.default()."""
+        with patch("google.auth.default") as mock_adc:
+            YouTubeApiClient(api_key="my-key")
             mock_adc.assert_not_called()
 
-    def test_init_passes_anonymous_credentials_to_build(self) -> None:
-        """build() must receive AnonymousCredentials to bypass ADC lookup.
+    def test_init_stores_api_key(self) -> None:
+        client = YouTubeApiClient(api_key="abc-123")
+        assert client._api_key == "abc-123"
 
-        Passing http= is insufficient in newer google-api-python-client versions;
-        build_from_document() calls _auth.default_credentials() even when http is
-        provided unless credentials are explicitly supplied.
-        """
-        with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
-            mock_build.return_value = MagicMock()
+    def test_init_makes_no_network_calls(self) -> None:
+        """Construction must be free of network I/O."""
+        with patch("urllib.request.urlopen") as mock_open:
+            YouTubeApiClient(api_key="my-key")
+            mock_open.assert_not_called()
 
-            YouTubeApiClient(api_key="fake-api-key")
 
-            _, kwargs = mock_build.call_args
-            assert isinstance(kwargs.get("credentials"), AnonymousCredentials)
+# ── _yt_get helper ────────────────────────────────────────────────────────────
 
-    def test_init_does_not_pass_http_to_build(self) -> None:
-        """build() must NOT receive an http argument (would conflict with credentials)."""
-        with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
-            mock_build.return_value = MagicMock()
 
-            YouTubeApiClient(api_key="fake-api-key")
+class TestYtGet:
+    def test_returns_parsed_json(self) -> None:
+        payload = {"items": [{"id": "v1"}]}
+        with patch("urllib.request.urlopen", return_value=_make_urlopen_response(payload)):
+            result = _yt_get("https://example.com")
+        assert result == payload
 
-            _, kwargs = mock_build.call_args
-            assert "http" not in kwargs
+    def test_raises_quota_exceeded_on_403(self) -> None:
+        with (
+            patch("urllib.request.urlopen", side_effect=_make_http_error(403, "quota")),
+            pytest.raises(QuotaExceededException, match="HTTP 403"),
+        ):
+            _yt_get("https://example.com")
 
-    def test_init_passes_developer_key_to_build(self) -> None:
-        """build() must receive the API key as developerKey."""
-        with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
-            mock_build.return_value = MagicMock()
+    def test_raises_youtube_api_error_on_other_http_error(self) -> None:
+        with (
+            patch("urllib.request.urlopen", side_effect=_make_http_error(500, "server")),
+            pytest.raises(YouTubeApiError, match="HTTP 500"),
+        ):
+            _yt_get("https://example.com")
 
-            YouTubeApiClient(api_key="my-secret-key")
+    def test_raises_youtube_api_error_on_url_error(self) -> None:
+        err = urllib.error.URLError(reason="connection refused")
+        with (
+            patch("urllib.request.urlopen", side_effect=err),
+            pytest.raises(YouTubeApiError, match="URL error"),
+        ):
+            _yt_get("https://example.com")
 
-            _, kwargs = mock_build.call_args
-            assert kwargs.get("developerKey") == "my-secret-key"
 
-    def test_init_disables_discovery_cache(self) -> None:
-        """build() must be called with cache_discovery=False."""
-        with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
-            mock_build.return_value = MagicMock()
+# ── YouTubeApiClient.search_page ──────────────────────────────────────────────
 
-            YouTubeApiClient(api_key="fake-api-key")
+_SEARCH_RESPONSE = {
+    "items": [{"id": {"videoId": "vid1"}}, {"id": {"videoId": "vid2"}}],
+    "nextPageToken": "token_next",
+}
 
-            _, kwargs = mock_build.call_args
-            assert kwargs.get("cache_discovery") is False
+_VIDEOS_RESPONSE = {
+    "items": [
+        {
+            "id": "vid1",
+            "snippet": {
+                "title": "Title 1",
+                "description": "Desc 1",
+                "channelId": "ch1",
+                "channelTitle": "Channel 1",
+                "publishedAt": "2024-01-01T00:00:00Z",
+                "thumbnails": {},
+                "categoryId": "22",
+            },
+            "contentDetails": {"duration": "PT5M"},
+            "statistics": {"viewCount": "100", "likeCount": "10"},
+        },
+        {
+            "id": "vid2",
+            "snippet": {
+                "title": "Title 2",
+                "description": "Desc 2",
+                "channelId": "ch2",
+                "channelTitle": "Channel 2",
+                "publishedAt": "2024-02-01T00:00:00Z",
+                "thumbnails": {},
+                "categoryId": "22",
+            },
+            "contentDetails": {"duration": "PT3M"},
+            "statistics": {"viewCount": "50"},
+        },
+    ]
+}
+
+
+def _make_search_page_client() -> tuple[YouTubeApiClient, list[MagicMock]]:
+    """Build a client whose urlopen calls return search then videos responses."""
+    client = YouTubeApiClient(api_key="test-key")
+    calls: list[MagicMock] = []
+
+    def _side_effect(url: str) -> MagicMock:
+        if "/search" in url:
+            resp = _make_urlopen_response(_SEARCH_RESPONSE)
+        else:
+            resp = _make_urlopen_response(_VIDEOS_RESPONSE)
+        calls.append(MagicMock(url=url))
+        return resp
+
+    return client, calls, _side_effect  # type: ignore[return-value]
+
+
+class TestYouTubeApiClientSearchPage:
+    def test_returns_video_metadatas(self, mocker) -> None:
+        client = YouTubeApiClient(api_key="key")
+        responses = [
+            _make_urlopen_response(_SEARCH_RESPONSE),
+            _make_urlopen_response(_VIDEOS_RESPONSE),
+        ]
+        mocker.patch("urllib.request.urlopen", side_effect=responses)
+        from mimesis.video_discovery.domain.models import SearchQuery
+
+        page = client.search_page(SearchQuery(keyword="test"), page_size=2)
+        assert len(page.video_metadatas) == 2
+        assert page.next_page_token == "token_next"
+
+    def test_api_key_included_in_request_url(self, mocker) -> None:
+        client = YouTubeApiClient(api_key="secret-key")
+        captured_urls: list[str] = []
+
+        def _capture(url: str) -> MagicMock:
+            captured_urls.append(url)
+            if "/search" in url:
+                return _make_urlopen_response(_SEARCH_RESPONSE)
+            return _make_urlopen_response(_VIDEOS_RESPONSE)
+
+        mocker.patch("urllib.request.urlopen", side_effect=_capture)
+        from mimesis.video_discovery.domain.models import SearchQuery
+
+        client.search_page(SearchQuery(keyword="test"), page_size=2)
+        assert all("key=secret-key" in u for u in captured_urls)
+
+    def test_returns_empty_page_when_no_search_results(self, mocker) -> None:
+        client = YouTubeApiClient(api_key="key")
+        mocker.patch(
+            "urllib.request.urlopen",
+            return_value=_make_urlopen_response({"items": []}),
+        )
+        from mimesis.video_discovery.domain.models import SearchQuery
+
+        page = client.search_page(SearchQuery(keyword="test"), page_size=5)
+        assert page.video_metadatas == []
+        assert page.next_page_token is None
+
+    def test_propagates_quota_exceeded_exception(self, mocker) -> None:
+        client = YouTubeApiClient(api_key="key")
+        mocker.patch("urllib.request.urlopen", side_effect=_make_http_error(403, "quota exceeded"))
+        from mimesis.video_discovery.domain.models import SearchQuery
+
+        with pytest.raises(QuotaExceededException):
+            client.search_page(SearchQuery(keyword="test"), page_size=5)

--- a/tests/unit/test_youtube_api_client.py
+++ b/tests/unit/test_youtube_api_client.py
@@ -1,7 +1,13 @@
-"""Unit tests for YouTubeApiClient — covers ADC regression (issue #25).
+"""Unit tests for YouTubeApiClient — covers ADC regression (issues #25, #27).
 
 These tests verify that YouTubeApiClient construction does NOT trigger
 google.auth.default() (which fails in Azure where no Google ADC is present).
+
+Root cause (issue #27): passing http=httplib2.Http() to build() is insufficient
+because google-api-python-client calls _auth.default_credentials() inside
+build_from_document() regardless of whether http is provided. The correct fix
+is to pass credentials=AnonymousCredentials(), which prevents the ADC lookup.
+
 The googleapiclient.discovery.build call is patched to avoid network I/O.
 """
 
@@ -9,13 +15,13 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import httplib2
+from google.auth.credentials import AnonymousCredentials
 
 from mimesis.video_discovery.infra.youtube_api_client import YouTubeApiClient
 
 
 class TestYouTubeApiClientInit:
-    """Regression tests for issue #25 — missing Google ADC in Azure."""
+    """Regression tests for issues #25 and #27 — missing Google ADC in Azure."""
 
     def test_init_does_not_call_google_auth_default(self) -> None:
         """Constructing YouTubeApiClient must never invoke google.auth.default().
@@ -33,15 +39,30 @@ class TestYouTubeApiClientInit:
 
             mock_adc.assert_not_called()
 
-    def test_init_passes_httplib2_http_to_build(self) -> None:
-        """build() must receive an httplib2.Http instance to bypass ADC lookup."""
+    def test_init_passes_anonymous_credentials_to_build(self) -> None:
+        """build() must receive AnonymousCredentials to bypass ADC lookup.
+
+        Passing http= is insufficient in newer google-api-python-client versions;
+        build_from_document() calls _auth.default_credentials() even when http is
+        provided unless credentials are explicitly supplied.
+        """
         with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
             mock_build.return_value = MagicMock()
 
             YouTubeApiClient(api_key="fake-api-key")
 
             _, kwargs = mock_build.call_args
-            assert isinstance(kwargs.get("http"), httplib2.Http)
+            assert isinstance(kwargs.get("credentials"), AnonymousCredentials)
+
+    def test_init_does_not_pass_http_to_build(self) -> None:
+        """build() must NOT receive an http argument (would conflict with credentials)."""
+        with patch("mimesis.video_discovery.infra.youtube_api_client.build") as mock_build:
+            mock_build.return_value = MagicMock()
+
+            YouTubeApiClient(api_key="fake-api-key")
+
+            _, kwargs = mock_build.call_args
+            assert "http" not in kwargs
 
     def test_init_passes_developer_key_to_build(self) -> None:
         """build() must receive the API key as developerKey."""


### PR DESCRIPTION
## Problem

Fixes #27 (regression from #25).

The `VideoDiscovery` function failed immediately on cold-start in Azure with:

```
google.auth.exceptions.DefaultCredentialsError: Your default credentials were not found.
```

Root cause: `google-api-python-client` (used by the original `YouTubeApiClient`) unconditionally calls `google.auth.default()` inside `build_from_document()` for some installed versions — even when a `developerKey` is explicitly passed at call time. Inside Azure Functions there are no Google Application Default Credentials, so this always raises.

## Solution

Rewrote `YouTubeApiClient` using Python stdlib `urllib` only. No Google auth library is involved at all.

**Two-call strategy per page (ADR-03 unchanged):**
1. `search.list` → videoIds
2. `videos.list` → full metadata batch (1 quota unit per batch)

**Additional improvements in this PR:**
- 403 responses are now parsed for the Google API JSON `reason` field before raising:
  - `quotaExceeded` / `dailyLimitExceeded` → `QuotaExceededException`
  - All other 403 reasons (e.g. `ipRefererBlocked`, `accessNotConfigured`) → `YouTubeApiError` — avoiding silent misclassification as quota errors
- `YouTubeApiClient.__init__` logs the last 4 chars of the API key to confirm which key Azure is using vs. what is in Key Vault
- Service error logging now includes the full exception message for App Insights visibility
- CI deploy pipeline replaced `az functionapp deploy` (consistently returned 502 from Kudu SCM on Flex Consumption) with direct blob upload + `kudu-state.json` update — see commit history for full root cause analysis

## Testing

- 66/66 unit tests pass (`pytest tests/unit/`)
- `ruff`, `black`, `mypy` clean
- Deployed to DEV and confirmed via App Insights: `Running the updated version — urllib-based YouTubeApiClient` log message present on invocation