### PR TITLE
fix(terraform): add missing Service Bus managed identity app settings to video-ingestion fn

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -268,6 +268,8 @@ resource "azapi_resource" "video_ingestion" {
           { name = "MIMESIS_SERVICE_BUS_INGESTED_QUEUE", value = azurerm_servicebus_queue.video_ingested.name },
           { name = "MIMESIS_APP_INSIGHTS_CONNECTION_STRING", value = azurerm_application_insights.main.connection_string },
           { name = "MIMESIS_SERVICE_BUS__fullyQualifiedNamespace", value = "${azurerm_servicebus_namespace.main.name}.servicebus.windows.net" },
+          { name = "MIMESIS_SERVICE_BUS__credential", value = "managedidentity" },
+          { name = "MIMESIS_SERVICE_BUS__clientId", value = azurerm_user_assigned_identity.main.client_id },
         ]
       }
     }


### PR DESCRIPTION
## Root Cause

The Service Bus trigger binding in `mimesis-fi-fn` uses `connection="MIMESIS_SERVICE_BUS"`. The Azure Functions runtime resolves this prefix against a family of `MIMESIS_SERVICE_BUS__*` app settings.

For **user-assigned managed identity** authentication, three settings are required:

| Setting | Status |
|---|---|
| `MIMESIS_SERVICE_BUS__fullyQualifiedNamespace` | ✅ already present |
| `MIMESIS_SERVICE_BUS__credential` | ❌ missing — added |
| `MIMESIS_SERVICE_BUS__clientId` | ❌ missing — added |

Without `__credential` and `__clientId`, the runtime cannot resolve the user-assigned identity and reports **"No existing connections available"** — the trigger never fires.

## Fix

Added the two missing app settings to the `azurerm_linux_function_app` (video ingestion) resource in `main.tf`, mirroring the identical pattern already used for `AzureWebJobsStorage__credential` / `AzureWebJobsStorage__clientId` in the same block.

## Verification

- `terraform fmt -check` ✅
- `terraform validate` ✅ (only pre-existing deprecation warnings, no errors)

## Acceptance Criteria

- **AC-01** ✅ After `terraform apply`, the trigger binding will have a valid managed identity connection.
- **AC-04** ✅ Fix is expressed entirely in Terraform — no manual portal changes.

Closes #32