### PR TITLE
fix: add Storage Queue Data Contributor role so fi-fn Service Bus trigger fires

### DIFF
--- a/.github/workflows/dev-rollout.yml
+++ b/.github/workflows/dev-rollout.yml
@@ -384,6 +384,30 @@ jobs:
           fi
           echo "Smoke test PASSED — HTTP $http_status"
 
+      - name: Smoke-trigger BC-01 (seed Service Bus queue)
+        run: |
+          FUNC_KEY="${{ steps.get-key.outputs.function_key }}"
+          FUNC_URL="${{ env.AZURE_BC01_FUNCTION_URL }}"
+          EXTRA_HEADERS=()
+          if [ -n "$FUNC_KEY" ]; then
+            EXTRA_HEADERS=(-H "x-functions-key: $FUNC_KEY")
+          fi
+          http_status=$(curl -s -w "\n%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            "${EXTRA_HEADERS[@]}" \
+            -d '{"keyword":"Gil Gomes Conta","max_results":6}' \
+            "$FUNC_URL")
+          body=$(echo "$http_status" | head -n -1)
+          status=$(echo "$http_status" | tail -n 1)
+          echo "HTTP status: $status"
+          echo "Response body: $body"
+          if [ "$status" -ne 200 ]; then
+            echo "::warning::BC-01 seed call returned HTTP $status — Service Bus queue may not be seeded for BC-02 trigger check."
+          else
+            echo "BC-01 seed call succeeded — Service Bus queue seeded."
+          fi
+
       - name: Smoke test BC-02 function app (health)
         run: |
           APP="${{ env.AZURE_BC02_FUNCTION_APP_NAME }}"

--- a/infrastructure/terraform/rbac.tf
+++ b/infrastructure/terraform/rbac.tf
@@ -43,3 +43,15 @@ resource "azurerm_role_assignment" "mi_sb_receiver" {
   role_definition_name = "Azure Service Bus Data Receiver"
   principal_id         = azurerm_user_assigned_identity.main.principal_id
 }
+
+# ── Managed Identity: Storage Queue Data Contributor ─────────────────────────
+# Required by the Azure Functions runtime when AzureWebJobsStorage uses managed
+# identity authentication. Without queue access, the runtime cannot manage its
+# internal queue-based orchestration, which prevents Service Bus triggers from
+# being reliably registered and invoked.
+
+resource "azurerm_role_assignment" "mi_queue_contributor" {
+  scope                = azurerm_storage_account.main.id
+  role_definition_name = "Storage Queue Data Contributor"
+  principal_id         = azurerm_user_assigned_identity.main.principal_id
+}


### PR DESCRIPTION
## Root Cause

The `mimesis-dev-fi-fn` (BC-02 Video Ingestion) Azure Function uses `AzureWebJobsStorage` with managed identity authentication. The Azure Functions runtime requires **three** storage data-plane roles to operate correctly with managed identity:

| Role | Purpose |
|---|---|
| `Storage Blob Data Contributor` | Package deployment and blob artifact storage |
| `Storage Table Data Contributor` | Internal runtime state tracking |
| `Storage Queue Data Contributor` | **Internal queue-based trigger orchestration** ← was missing |

Without `Storage Queue Data Contributor`, the Functions runtime cannot manage its internal queue-based orchestration. This silently prevents Service Bus triggers from being reliably registered and invoked — the app reports `"Running"` in ARM state but the `sb-queue-video-discovered` trigger is never wired up correctly.

## Fix Applied

### `infrastructure/terraform/rbac.tf`

Added a new `azurerm_role_assignment` block:

```hcl
resource "azurerm_role_assignment" "mi_queue_contributor" {
  scope                = azurerm_storage_account.main.id
  role_definition_name = "Storage Queue Data Contributor"
  principal_id         = azurerm_user_assigned_identity.main.principal_id
}
```

### `.github/workflows/dev-rollout.yml`

Added a **"Smoke-trigger BC-01 (seed Service Bus queue)"** step before the BC-02 health check. This step calls BC-01 with a real keyword (`Gil Gomes Conta`, max 6 results) to publish a `VideoDiscovered` event to `sb-queue-video-discovered`, seeding the queue so the subsequent 90-second blob-presence poll can confirm BC-02's trigger actually fires end-to-end.

The step uses `::warning::` (not `exit 1`) on non-200 responses to tolerate cold-start transient errors.

## How to Validate

### 1. Run Dev Rollout

Trigger the **DEV Rollout** workflow on this PR's branch. The pipeline will:
1. Apply Terraform (grants the new role to the managed identity)
2. Deploy both function apps
3. Smoke-trigger BC-01 with a real keyword → publishes to `sb-queue-video-discovered`
4. Poll `raw-videos` for 90 s → should find blobs written by the newly-triggered BC-02

### 2. Manual verification with curl

After Dev Rollout completes, fetch the BC-01 host key and call it directly:

```bash
# Replace with actual values from your environment
FUNC_URL="<AZURE_BC01_FUNCTION_URL>"
FUNC_KEY="<your-bc01-host-key>"

curl -s -w "\nHTTP %{http_code}\n" \
  -X POST \
  -H "Content-Type: application/json" \
  -H "x-functions-key: $FUNC_KEY" \
  -d '{"keyword":"Gil Gomes Conta","max_results":6}' \
  "$FUNC_URL"
```

Then check the `raw-videos` container for new blobs:

```bash
STORAGE_ACCOUNT=mimesisdevsa   # derived from resource group mimesis-dev-rg

az storage blob list \
  --account-name "$STORAGE_ACCOUNT" \
  --container-name raw-videos \
  --auth-mode login \
  --query "[].name" -o table
```

If BC-02 is now correctly triggered, blobs will appear under `raw-videos/<YYYY/MM/DD>/<video_id>/source.mp4`.

## Checklist

- [x] `terraform fmt -check -recursive` passes
- [x] `terraform init -backend=false && terraform validate` passes (warnings only, no errors)
- [x] No empty `env:` block at workflow level
- [x] Smoke test uses `::warning::` for non-200 BC-01 seed response
- [x] `git push --force` not used
- [x] Only `rbac.tf` and `dev-rollout.yml` changed — no Python/Coding-agent boundary crossed
