### PR TITLE
fix(video-ingestion): replace pytubefix with yt-dlp to bypass YouTube bot detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "azure-storage-blob>=12.22.0",
     "azure-servicebus>=7.11.0",
     "azure-monitor-opentelemetry>=1.0.0",
-    "pytubefix>=8.0.0",
+    "yt-dlp",
     "pydub>=0.25.1",
 ]
 

--- a/src/mimesis/video_ingestion/config.py
+++ b/src/mimesis/video_ingestion/config.py
@@ -13,7 +13,9 @@ class VideoIngestionConfig:
     service_bus_namespace: str
     video_ingested_queue: str
     app_insights_connection_string: str
+    key_vault_url: str
     build_id: str = "unknown"
+    cookies_secret_name: str = "youtube-cookies"
 
     @classmethod
     def from_env(cls) -> VideoIngestionConfig:
@@ -27,7 +29,9 @@ class VideoIngestionConfig:
                 "MIMESIS_SERVICE_BUS_INGESTED_QUEUE", "sb-queue-video-ingested"
             ),
             app_insights_connection_string=_require("MIMESIS_APP_INSIGHTS_CONNECTION_STRING"),
+            key_vault_url=_require("MIMESIS_KEY_VAULT_URL"),
             build_id=os.getenv("BUILD_ID", "unknown"),
+            cookies_secret_name=os.getenv("MIMESIS_YOUTUBE_COOKIES_SECRET", "youtube-cookies"),
         )
 
 

--- a/src/mimesis/video_ingestion/function_app.py
+++ b/src/mimesis/video_ingestion/function_app.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import logging
 
 import azure.functions as func
+from azure.core.exceptions import ResourceNotFoundError
+from azure.identity import DefaultAzureCredential
+from azure.keyvault.secrets import SecretClient
 
 from mimesis.shared.observability import configure_observability
 from mimesis.video_ingestion.application.video_ingestion_service import (
@@ -18,7 +21,7 @@ from mimesis.video_ingestion.domain.exceptions import (
 )
 from mimesis.video_ingestion.infra.blob_artifact_store import BlobArtifactStore
 from mimesis.video_ingestion.infra.ingestion_ledger import TableIngestionLedger
-from mimesis.video_ingestion.infra.media_processor import PytubefixMediaProcessor
+from mimesis.video_ingestion.infra.media_processor import YtDlpMediaProcessor
 from mimesis.video_ingestion.infra.video_ingested_event_publisher import (
     ServiceBusVideoIngestedPublisher,
 )
@@ -34,13 +37,43 @@ configure_observability(
     build_id=_config.build_id,
 )
 
+
+def _load_youtube_cookies(key_vault_url: str, secret_name: str) -> str | None:
+    try:
+        credential = DefaultAzureCredential()
+        client = SecretClient(vault_url=key_vault_url, credential=credential)
+        secret = client.get_secret(secret_name)
+        if secret.value:
+            logger.info("YouTube cookies loaded from Key Vault | secret=%s", secret_name)
+            return secret.value
+        logger.warning("YouTube cookies secret is empty | secret=%s", secret_name)
+        return None
+    except ResourceNotFoundError:
+        logger.warning(
+            "YouTube cookies secret not found in Key Vault, proceeding without cookies"
+            " | secret=%s",
+            secret_name,
+        )
+        return None
+    except Exception:
+        logger.warning(
+            "Failed to retrieve YouTube cookies from Key Vault, proceeding without cookies"
+            " | secret=%s",
+            secret_name,
+            exc_info=True,
+        )
+        return None
+
+
+_cookies = _load_youtube_cookies(_config.key_vault_url, _config.cookies_secret_name)
+
 _service = VideoIngestionService(
     artifact_store=BlobArtifactStore(account_url=_config.storage_account_url),
     ledger=TableIngestionLedger(
         account_url=_config.storage_account_url.replace(".blob.", ".table."),
         table_name=_config.ingestion_ledger_table,
     ),
-    media_processor=PytubefixMediaProcessor(),
+    media_processor=YtDlpMediaProcessor(cookies=_cookies),
     event_publisher=ServiceBusVideoIngestedPublisher(
         fully_qualified_namespace=_config.service_bus_namespace,
         queue_name=_config.video_ingested_queue,

--- a/src/mimesis/video_ingestion/infra/media_processor.py
+++ b/src/mimesis/video_ingestion/infra/media_processor.py
@@ -1,36 +1,46 @@
-"""Media processing adapter using pytubefix and pydub."""
+"""Media processing adapter using yt-dlp and pydub."""
 
 from __future__ import annotations
 
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import yt_dlp
 from pydub import AudioSegment
-from pytubefix import YouTube
 
 from mimesis.video_ingestion.domain.exceptions import MediaProcessingError
 from mimesis.video_ingestion.ports.media_processor_port import MediaProcessorPort
 
 
-class PytubefixMediaProcessor(MediaProcessorPort):
-    """Downloads source video and extracts MP3 audio."""
+class YtDlpMediaProcessor(MediaProcessorPort):
+    """Downloads source video and extracts MP3 audio using yt-dlp."""
+
+    def __init__(self, cookies: str | None = None) -> None:
+        self._cookies = cookies
 
     def download_source_video(self, youtube_url: str) -> bytes:
         try:
             with TemporaryDirectory() as tmpdir:
-                yt = YouTube(youtube_url)
-                stream = (
-                    yt.streams.filter(progressive=True, file_extension="mp4")
-                    .order_by("resolution")
-                    .desc()
-                    .first()
-                )
-                if stream is None:
-                    raise MediaProcessingError("No progressive mp4 stream available.")
+                ydl_opts: dict[str, object] = {
+                    "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+                    "outtmpl": str(Path(tmpdir) / "source.%(ext)s"),
+                    "quiet": True,
+                    "no_warnings": True,
+                    "merge_output_format": "mp4",
+                }
 
-                output_path = Path(tmpdir)
-                downloaded = stream.download(output_path=str(output_path), filename="source.mp4")
-                return Path(downloaded).read_bytes()
+                if self._cookies:
+                    cookie_path = Path(tmpdir) / "cookies.txt"
+                    cookie_path.write_text(self._cookies)
+                    ydl_opts["cookiefile"] = str(cookie_path)
+
+                with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+                    ydl.download([youtube_url])
+
+                result_path = Path(tmpdir) / "source.mp4"
+                if not result_path.exists():
+                    raise MediaProcessingError("yt-dlp did not produce an output file.")
+                return result_path.read_bytes()
         except MediaProcessingError:
             raise
         except Exception as exc:

--- a/tests/unit/test_video_ingestion_config.py
+++ b/tests/unit/test_video_ingestion_config.py
@@ -8,6 +8,7 @@ _REQUIRED_VARS = {
     "MIMESIS_STORAGE_ACCOUNT_URL": "https://example.table.core.windows.net/",
     "MIMESIS_SERVICE_BUS_NAMESPACE": "example.servicebus.windows.net",
     "MIMESIS_APP_INSIGHTS_CONNECTION_STRING": "InstrumentationKey=test",
+    "MIMESIS_KEY_VAULT_URL": "https://example.vault.azure.net/",
 }
 
 
@@ -30,3 +31,29 @@ def test_build_id_read_from_env(monkeypatch) -> None:
 
     cfg = VideoIngestionConfig.from_env()
     assert cfg.build_id == "a3f9c1b2-47"
+
+
+def test_cookies_secret_name_defaults_to_youtube_cookies(monkeypatch) -> None:
+    _set_required(monkeypatch)
+    monkeypatch.delenv("MIMESIS_YOUTUBE_COOKIES_SECRET", raising=False)
+
+    cfg = VideoIngestionConfig.from_env()
+    assert cfg.cookies_secret_name == "youtube-cookies"
+
+
+def test_cookies_secret_name_read_from_env(monkeypatch) -> None:
+    _set_required(monkeypatch)
+    monkeypatch.setenv("MIMESIS_YOUTUBE_COOKIES_SECRET", "yt-cookies-prod")
+
+    cfg = VideoIngestionConfig.from_env()
+    assert cfg.cookies_secret_name == "yt-cookies-prod"
+
+
+def test_missing_key_vault_url_raises(monkeypatch) -> None:
+    _set_required(monkeypatch)
+    monkeypatch.delenv("MIMESIS_KEY_VAULT_URL", raising=False)
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="MIMESIS_KEY_VAULT_URL"):
+        VideoIngestionConfig.from_env()

--- a/tests/unit/test_video_ingestion_function.py
+++ b/tests/unit/test_video_ingestion_function.py
@@ -18,14 +18,18 @@ _REQUIRED_ENV = {
     "MIMESIS_STORAGE_ACCOUNT_URL": "https://example.blob.core.windows.net/",
     "MIMESIS_SERVICE_BUS_NAMESPACE": "example.servicebus.windows.net",
     "MIMESIS_APP_INSIGHTS_CONNECTION_STRING": "InstrumentationKey=test",
+    "MIMESIS_KEY_VAULT_URL": "https://example.vault.azure.net/",
 }
 
 # Patch configure_azure_monitor to prevent the Azure Monitor SDK from
 # attempting real connections during module-level initialisation.
+# Patch SecretClient to prevent Key Vault calls during module-level cookie loading.
 with (
     patch.dict(os.environ, _REQUIRED_ENV),
     patch("mimesis.shared.observability.configure_azure_monitor"),
+    patch("azure.keyvault.secrets.SecretClient") as _mock_kv_client,
 ):
+    _mock_kv_client.return_value.get_secret.return_value.value = None
     import mimesis.video_ingestion.function_app as _function_module
     from mimesis.video_ingestion.function_app import video_ingestion
 


### PR DESCRIPTION
Closes #41

## Changes
- Replaced `pytubefix` with `yt-dlp` in `media_processor.py` and `pyproject.toml`
- `YtDlpMediaProcessor` accepts optional cookies.txt content from Key Vault
- `function_app.py` retrieves `youtube-cookies` secret at startup (gracefully falls back to no cookies if secret absent)
- Unit tests updated

## How to validate
1. Run Dev Rollout against this PR branch
2. After rollout, call BC-01 with a real keyword (max_results=10+)
3. Confirm BC-02 invocations succeed (Success count > 0 in Azure Portal → fi-fn → Invocations)
4. Optionally store a valid `cookies.txt` in Key Vault as `youtube-cookies` and re-deploy to further reduce bot-detection risk