### PR TITLE
fix(terraform): add MIMESIS_KEY_VAULT_URL app setting to fi-fn

### DIFF
--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -280,6 +280,7 @@ resource "azapi_resource" "video_ingestion" {
           { name = "MIMESIS_SERVICE_BUS__fullyQualifiedNamespace", value = "${azurerm_servicebus_namespace.main.name}.servicebus.windows.net" },
           { name = "MIMESIS_SERVICE_BUS__credential", value = "managedidentity" },
           { name = "MIMESIS_SERVICE_BUS__clientId", value = azurerm_user_assigned_identity.main.client_id },
+          { name = "MIMESIS_KEY_VAULT_URL", value = azurerm_key_vault.main.vault_uri },
         ]
       }
     }


### PR DESCRIPTION
## Summary

Fixes the Terraform drift that caused `mimesis-dev-fi-fn` (BC-02) to start with **0 functions loaded** since PR #42 was deployed.

## Root Cause

PR #42 added `key_vault_url=_require('MIMESIS_KEY_VAULT_URL')` to `VideoIngestionConfig`. The `_require()` helper raises `RuntimeError` at startup if the env var is absent, which prevented the Python worker from registering any functions — resulting in the Service Bus trigger never firing.

`MIMESIS_KEY_VAULT_URL` was not added to fi-fn's Terraform `appSettings` block in the same PR.

## Change

Added to fi-fn `siteConfig.appSettings` in `infrastructure/terraform/main.tf`:

```hcl
{ name = "MIMESIS_KEY_VAULT_URL", value = azurerm_key_vault.main.vault_uri },
```

The setting was applied to the live environment manually (via `az functionapp config appsettings set`) to unblock BC-02 immediately. This PR makes it permanent in IaC.

## Testing

- After the manual fix, fi-fn started with `1 functions loaded` and processed 3 queued Service Bus messages (confirmed in App Insights at 2026-04-17T22:04:58)
- yt-dlp still fails with bot detection (tracked in #43) — but the function loading issue is resolved

Closes #43