### PR TITLE
fix: document youtube-cookies Key Vault workflow (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,50 @@
 # mimesis
+
 Mimesis — learns a storyteller's writing style and voice from YouTube videos, then generates and narrates new stories from current news using the same voice.
+
+## Operations
+
+### Refreshing YouTube cookies
+
+YouTube's bot-detection blocks requests from Azure datacenter IPs. To bypass this, Mimesis reads a Netscape-format `cookies.txt` from a logged-in YouTube session stored in Key Vault as the `youtube-cookies` secret.
+
+Cookies expire over time (typically within weeks). Follow these steps to refresh them:
+
+#### 1. Export cookies from Firefox
+
+Use [firefox_cookie_exporter_cli](https://github.com/marceltoledo/firefox_cookie_exporter_cli) while logged into YouTube in Firefox:
+
+```bash
+# Install
+pip install fcookex
+
+# Export ALL youtube.com cookies in one shot (no interactive prompt)
+fcookex --search youtube.com --all --output youtube-cookies
+# Writes export/youtube-cookies.txt
+```
+
+> Alternatively, export interactively (omit `--all`) to hand-pick individual cookies.
+
+#### 2. Upload to Key Vault
+
+```bash
+az keyvault secret set \
+  --vault-name mimesis-dev-kv \
+  --name youtube-cookies \
+  --file export/youtube-cookies.txt
+```
+
+For production:
+
+```bash
+az keyvault secret set \
+  --vault-name mimesis-prod-kv \
+  --name youtube-cookies \
+  --file export/youtube-cookies.txt
+```
+
+#### 3. Verify
+
+The `VideoIngestion` function loads the secret on cold-start. Trigger a fresh invocation and confirm success in App Insights — no `Sign in to confirm you're not a bot` errors should appear.
+
+> The `youtube-cookies` secret is managed out-of-band (not via Terraform) because cookies rotate frequently. The Terraform state does not contain cookie values.

--- a/infrastructure/terraform/secrets.tfvars.example
+++ b/infrastructure/terraform/secrets.tfvars.example
@@ -2,3 +2,9 @@
 # ⚠️  Files matching *.secrets.tfvars are gitignored — never commit them.
 
 youtube_api_key = "<your-youtube-data-api-v3-key>"
+
+# youtube-cookies is NOT managed via Terraform — cookies rotate frequently.
+# Upload out-of-band using:
+#   fcookex --search youtube.com --all --output youtube-cookies
+#   az keyvault secret set --vault-name mimesis-<env>-kv --name youtube-cookies --file export/youtube-cookies.txt
+# See README.md for full instructions.


### PR DESCRIPTION
## Summary

Implements #43 — documents the YouTube cookie refresh workflow using [`firefox_cookie_exporter_cli`](https://github.com/marceltoledo/firefox_cookie_exporter_cli) and explains how to upload the exported cookies to Azure Key Vault.

No Python source changes were needed: the Video Ingestion function already reads the `youtube-cookies` secret from Key Vault at cold-start via `_load_youtube_cookies()` and passes it to `YtDlpMediaProcessor`.

## Changes

### `README.md`

Added an **Operations** section: *Refreshing YouTube cookies*.

- Explains why cookies are needed (Azure egress IPs trigger YouTube's bot-detection)
- Step 1 — export with `fcookex`:
  ```bash
  pip install fcookex
  fcookex --search youtube.com --all --output youtube-cookies
  ```
- Step 2 — upload to Key Vault (dev and prod):
  ```bash
  az keyvault secret set \
    --vault-name mimesis-dev-kv \
    --name youtube-cookies \
    --file export/youtube-cookies.txt
  ```
- Step 3 — verify via Application Insights
- Notes that `youtube-cookies` is managed **out-of-band** (not tracked by Terraform)

### `infrastructure/terraform/secrets.tfvars.example`

Added a comment block below `youtube_api_key` documenting the out-of-band management of `youtube-cookies` via `fcookex` + `az keyvault secret set`.

## How to test

1. Export cookies locally: `fcookex --search youtube.com --all --output youtube-cookies`
2. Upload to dev vault: `az keyvault secret set --vault-name mimesis-dev-kv --name youtube-cookies --file export/youtube-cookies.txt`
3. Trigger the Video Ingestion function and confirm no `yt-dlp` bot-detection errors in App Insights

## Notes

- The `youtube-cookies` secret is intentionally **not** managed by Terraform (it contains session credentials that rotate and must be refreshed manually)
- The function handles a missing secret gracefully (`_load_youtube_cookies()` returns `None` and logs a warning)
